### PR TITLE
Enable lognorm likelihood for D_dt

### DIFF
--- a/hierarc/Likelihood/lens_likelihood.py
+++ b/hierarc/Likelihood/lens_likelihood.py
@@ -33,6 +33,8 @@ class LensLikelihoodBase(object):
             self._lens_type = TDKinGaussian(z_lens, z_source, **kwargs_likelihood)
         elif likelihood_type in ['KinGaussian']:
             self._lens_type = KinLikelihoodGaussian(z_lens, z_source, **kwargs_likelihood)
+        elif likelihood_type == 'TDLogNorm':
+            self._lens_type = TDLikelihoodLogNorm(z_lens, z_source, **kwargs_likelihood)
         elif likelihood_type == 'TDKinSkewLogNorm':
             self._lens_type = TDKinLikelihoodSklogn(z_lens, z_source, **kwargs_likelihood)
         elif likelihood_type == 'TDSkewLogNorm':
@@ -122,7 +124,6 @@ class TDKinLikelihoodKDE(object):
             return self._interp_log_likelihood(dd_, ddt)[0]
         return self._kde_likelihood.logLikelihood(dd_, ddt)[0]
 
-
 class TDKinLikelihoodSklogn(object):
     """
     class for evaluating the 2-d posterior of Ddt vs Dd coming from a lens with time delays and kinematics measurement
@@ -196,7 +197,7 @@ class TDLikelihoodSklogn(object):
 class TDLikelihoodGaussian(object):
     """
     class to handle cosmographic likelihood coming from modeling lenses with imaging and kinematic data but no time delays.
-    Thus Ddt is not constraint but the kinematics can constrain Ds/Dds
+    Thus Ddt is not constrained but the kinematics can constrain Ds/Dds
 
     The current version includes a Gaussian in Ds/Dds but can be extended.
     """
@@ -223,11 +224,39 @@ class TDLikelihoodGaussian(object):
         """
         return - (ddt - self._ddt_mean) ** 2 / self._ddt_sigma2 / 2
 
+class TDLikelihoodLogNorm(object):
+    """
+    The cosmographic likelihood coming from modeling lenses with imaging and kinematic data but no time delays, where the form of the likelihood is a lognormal distribution.
+    Thus Ddt is not constrained but the kinematics can constrain Ds/Dds
+
+    The current version includes a Gaussian in Ds/Dds but can be extended.
+    """
+    def __init__(self, z_lens, z_source, ddt_mu, ddt_sigma):
+        """
+        :param z_lens: lens redshift
+        :param z_source: source redshift
+        :param ddt_mean: mean of log(Ddt distance)
+        :param ddt_sigma: 1-sigma uncertainty in the log(Ddt distance)
+        """
+        self._z_lens = z_lens
+        self._ddt_mu = ddt_mu
+        self._ddt_sigma2 = ddt_sigma ** 2
+
+    def log_likelihood(self, ddt, dd=None, aniso_scaling=None):
+        """
+        Note: kinematics + imaging data can constrain Ds/Dds. The input of Ddt, Dd is transformed here to match Ds/Dds
+
+        :param ddt: time-delay distance
+        :param dd: angular diameter distance to the deflector
+        :param aniso_scaling: numpy array of anisotropy scaling on prediction of Ds/Dds
+        :return: log likelihood given the single lens analysis
+        """
+        return -0.5*(np.log(ddt) - self._ddt_mu)**2/self._ddt_sigma2 - np.log(ddt) - 0.5*np.log(self._ddt_sigma2)
 
 class KinLikelihoodGaussian(object):
     """
     class to handle cosmographic likelihood coming from modeling lenses with imaging and kinematic data but no time delays.
-    Thus Ddt is not constraint but the kinematics can constrain Ds/Dds
+    Thus Ddt is not constrained but the kinematics can constrain Ds/Dds
 
     The current version includes a Gaussian in Ds/Dds but can be extended.
     """

--- a/tests/test_Likelihood/test_lens_likelihood.py
+++ b/tests/test_Likelihood/test_lens_likelihood.py
@@ -7,7 +7,7 @@ from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 from hierarc.Likelihood.lens_sample_likelihood import LensSampleLikelihood
 from hierarc.Likelihood.lens_likelihood import LensLikelihoodBase, TDKinLikelihoodKDE
 from astropy.cosmology import FlatLambdaCDM
-
+from scipy.stats import lognorm
 
 class TestLensLikelihood(object):
 
@@ -97,6 +97,22 @@ class TestTDKinLikelihoodKDE(object):
         logl_interp = tdkin_interp.log_likelihood(ddt=self.D_dt_true + 100000, dd=self.Dd_true+100000)
         #assert logl_interp == -np.inf
 
+class TestTDLikelihoodLogNorm(object):
+
+    def setup(self):
+        self.z_L = 0.8
+        self.z_S = 3.0
+        self.ddt_mu = 3.5
+        self.ddt_sigma = 0.2
+        self.kwargs_post = {'z_lens': self.z_L, 'z_source': self.z_S, 'ddt_mu': self.ddt_mu, 'ddt_sigma': self.ddt_sigma, 'likelihood_type': 'TDLogNorm'}
+        self.ddt_grid = np.arange(1, 10000, 50)
+        self.scipy_lognorm = lognorm(scale=np.exp(self.ddt_mu), s=self.ddt_sigma)
+        self.ll_object = LensLikelihoodBase(**self.kwargs_post)._lens_type
+
+    def test_log_likelihood(self):
+        ll = self.ll_object.log_likelihood(self.ddt_grid)
+        scipy_ll = self.scipy_lognorm.logpdf(self.ddt_grid) # with the constant term included
+        npt.assert_almost_equal(ll, scipy_ll + 0.5*np.log(2*np.pi), decimal=7)
 
 class TestRaise(unittest.TestCase):
 


### PR DESCRIPTION
The lognormal distribution (likelihood type `TDLognormal`) adds some skew flexibility to the existing `TDGaussian` likelihood. I've compared the log PDF values to scipy's as the most basic check.