### PR TITLE
Code formatting with black and docformatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ ENV/
 
 # IDE settings
 .vscode/
+.idea/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+    autofix_prs: true
+    autoupdate_branch: ''
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: monthly
+    skip: []
+    submodules: false
+
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black
+        # It is recommended to specify the latest version of Python
+        # supported by your project here, or alternatively use
+        # pre-commit's default_language_version, see
+        # https://pre-commit.com/#top_level-default_language_version
+        language_version: python3
+  - repo: https://github.com/psf/black
+    rev: 23.11.0
+    hooks:
+      - id: black-jupyter
+        language_version: python3
+  - repo: https://github.com/PyCQA/docformatter
+    rev: v1.7.5
+    hooks:
+      - id: docformatter
+        additional_dependencies: [tomli]
+        args: [-r, --black, --in-place]
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,8 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('..'))
+
+sys.path.insert(0, os.path.abspath(".."))
 
 import hierarc
 
@@ -31,22 +32,22 @@ import hierarc
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'hierArc'
+project = "hierArc"
 copyright = "2020, Simon Birrer"
 author = "Simon Birrer"
 
@@ -64,15 +65,15 @@ release = hierarc.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -83,7 +84,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
+html_theme = "default"
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the
@@ -94,13 +95,13 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ---------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'hierarcdoc'
+htmlhelp_basename = "hierarcdoc"
 
 
 # -- Options for LaTeX output ------------------------------------------
@@ -109,15 +110,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -127,9 +125,7 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'hierarc.tex',
-     'hierArc Documentation',
-     'Simon Birrer', 'manual'),
+    (master_doc, "hierarc.tex", "hierArc Documentation", "Simon Birrer", "manual"),
 ]
 
 
@@ -137,11 +133,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'hierarc',
-     'hierArc Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "hierarc", "hierArc Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -150,13 +142,13 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'hierarc',
-     'hierArc Documentation',
-     author,
-     'hierarc',
-     'One line description of project.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "hierarc",
+        "hierArc Documentation",
+        author,
+        "hierarc",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
-
-
-

--- a/hierarc/Diagnostics/blinding.py
+++ b/hierarc/Diagnostics/blinding.py
@@ -3,8 +3,7 @@ import copy
 
 
 def blind_posterior(posterior, param_names):
-    """
-    blinds H0 and lambda_int to default values
+    """Blinds H0 and lambda_int to default values.
 
     :param posterior: posterior samples of hierArc
     :type posterior: flattened posterior with num_param x num_samples array

--- a/hierarc/Diagnostics/blinding.py
+++ b/hierarc/Diagnostics/blinding.py
@@ -14,10 +14,10 @@ def blind_posterior(posterior, param_names):
     """
     posterior_blind = copy.deepcopy(posterior)
     for i, param_name in enumerate(param_names):
-        if param_name == 'lambda_mst':
+        if param_name == "lambda_mst":
             # shift all lambda_int posteriors to a median = 1
             posterior_blind[:, i] *= 1 / np.median(posterior_blind[:, i])
-        if param_name == 'h0':
+        if param_name == "h0":
             # shift all H0 posteriors to a mean = 70
             posterior_blind[:, i] *= 70 / np.median(posterior_blind[:, i])
     return posterior_blind

--- a/hierarc/Diagnostics/goodness_of_fit.py
+++ b/hierarc/Diagnostics/goodness_of_fit.py
@@ -7,6 +7,7 @@ class GoodnessOfFit(object):
     """
     class to manage goodness of fit diagnostics
     """
+
     def __init__(self, kwargs_likelihood_list):
         """
 
@@ -14,7 +15,9 @@ class GoodnessOfFit(object):
          LensLikelihood module
         """
         self._kwargs_likelihood_list = kwargs_likelihood_list
-        self._sample_likelihood = LensSampleLikelihood(kwargs_likelihood_list, normalized=False)
+        self._sample_likelihood = LensSampleLikelihood(
+            kwargs_likelihood_list, normalized=False
+        )
 
     def reduced_chi2(self, cosmo, kwargs_lens, kwargs_kin):
         """
@@ -25,8 +28,15 @@ class GoodnessOfFit(object):
         num_data = self._sample_likelihood.num_data()
         return -logL * 2 / num_data
 
-    def plot_ddt_fit(self, cosmo, kwargs_lens, kwargs_kin, color_measurement=None, color_prediction=None,
-                     redshift_trend=False):
+    def plot_ddt_fit(
+        self,
+        cosmo,
+        kwargs_lens,
+        kwargs_kin,
+        color_measurement=None,
+        color_prediction=None,
+        redshift_trend=False,
+    ):
         """
         plots the prediction and the uncorrelated error bars on the individual lenses
         currently works for likelihood classes 'TDKinGaussian', 'KinGaussian'
@@ -40,7 +50,7 @@ class GoodnessOfFit(object):
         :return: fig, axes of matplotlib instance
         """
         red_chi2 = self.reduced_chi2(cosmo, kwargs_lens, kwargs_kin)
-        print(red_chi2, 'reduced chi2')
+        print(red_chi2, "reduced chi2")
 
         ddt_name_list = []
         ddt_model_mean_list = []
@@ -51,12 +61,16 @@ class GoodnessOfFit(object):
         z_list = []
 
         for i, kwargs_likelihood in enumerate(self._kwargs_likelihood_list):
-            name = kwargs_likelihood.get('name', 'lens ' + str(i))
+            name = kwargs_likelihood.get("name", "lens " + str(i))
             likelihood = self._sample_likelihood._lens_list[i]
             ddt_mean_measurement, ddt_sigma_measurement = likelihood.ddt_measurement()
             if ddt_mean_measurement is not None:
-                ddt_model_mean, ddt_model_sigma, dd_model_mean, dd_model_sigma = likelihood.ddt_dd_model_prediction(
-                    cosmo, kwargs_lens=kwargs_lens)
+                (
+                    ddt_model_mean,
+                    ddt_model_sigma,
+                    dd_model_mean,
+                    dd_model_sigma,
+                ) = likelihood.ddt_dd_model_prediction(cosmo, kwargs_lens=kwargs_lens)
 
                 ddt_name_list.append(name)
                 ddt_model_mean_list.append(ddt_model_mean)
@@ -69,18 +83,48 @@ class GoodnessOfFit(object):
         else:
             x = np.arange(len(ddt_name_list))
 
-        f, ax = plt.subplots(1, 1, figsize=(len(ddt_name_list)/1.5, 4))
-        ax.errorbar(x, ddt_data_mean_list, yerr=ddt_data_sigma_list,
-                    color=color_measurement,
-                    xerr=None, fmt='o', ecolor=None, elinewidth=None,
-                    capsize=None, barsabove=False, lolims=False, uplims=False,
-                    xlolims=False, xuplims=False, errorevery=1, capthick=None, data=None, label='measurement')
+        f, ax = plt.subplots(1, 1, figsize=(len(ddt_name_list) / 1.5, 4))
+        ax.errorbar(
+            x,
+            ddt_data_mean_list,
+            yerr=ddt_data_sigma_list,
+            color=color_measurement,
+            xerr=None,
+            fmt="o",
+            ecolor=None,
+            elinewidth=None,
+            capsize=None,
+            barsabove=False,
+            lolims=False,
+            uplims=False,
+            xlolims=False,
+            xuplims=False,
+            errorevery=1,
+            capthick=None,
+            data=None,
+            label="measurement",
+        )
 
-        ax.errorbar(x, ddt_model_mean_list, yerr=ddt_model_sigma_list,
-                    color=color_prediction,
-                    xerr=None, fmt='o', ecolor=None, elinewidth=None,
-                    capsize=None, barsabove=False, lolims=False, uplims=False,
-                    xlolims=False, xuplims=False, errorevery=1, capthick=None, data=None, label='prediction')
+        ax.errorbar(
+            x,
+            ddt_model_mean_list,
+            yerr=ddt_model_sigma_list,
+            color=color_prediction,
+            xerr=None,
+            fmt="o",
+            ecolor=None,
+            elinewidth=None,
+            capsize=None,
+            barsabove=False,
+            lolims=False,
+            uplims=False,
+            xlolims=False,
+            xuplims=False,
+            errorevery=1,
+            capthick=None,
+            data=None,
+            label="prediction",
+        )
 
         if redshift_trend:
             # put redshift ticks on top of plot
@@ -88,11 +132,11 @@ class GoodnessOfFit(object):
             ax2.set_xlim(ax.get_xlim())
             # ax2.set_xticks(z_list)
             # ax2.set_xticklabels(labels=ddt_name_list, rotation='vertical')
-            ax2.set_xlabel('lens redshift', fontsize=15)
+            ax2.set_xlabel("lens redshift", fontsize=15)
 
         ax.set_xticks(ticks=x)
-        ax.set_xticklabels(labels=ddt_name_list, rotation='vertical')
-        ax.set_ylabel(r'$D_{\Delta t}$ [Mpc]', fontsize=15)
+        ax.set_xticklabels(labels=ddt_name_list, rotation="vertical")
+        ax.set_ylabel(r"$D_{\Delta t}$ [Mpc]", fontsize=15)
         ax.legend()
         return f, ax
 
@@ -114,10 +158,16 @@ class GoodnessOfFit(object):
         sigma_v_model_error_list = []
 
         for i, kwargs_likelihood in enumerate(self._kwargs_likelihood_list):
-            name = kwargs_likelihood.get('name', 'lens ' + str(i))
+            name = kwargs_likelihood.get("name", "lens " + str(i))
             likelihood = self._sample_likelihood._lens_list[i]
-            sigma_v_measurement, cov_error_measurement, sigma_v_predict_mean, cov_error_predict = likelihood.sigma_v_measured_vs_predict(
-                cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin)
+            (
+                sigma_v_measurement,
+                cov_error_measurement,
+                sigma_v_predict_mean,
+                cov_error_predict,
+            ) = likelihood.sigma_v_measured_vs_predict(
+                cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin
+            )
 
             if sigma_v_measurement is not None:
                 num = len(sigma_v_measurement)
@@ -131,9 +181,22 @@ class GoodnessOfFit(object):
                     sigma_v_measurement_error_list.append(sigma_v_sigma)
                     sigma_v_model_list.append(sigma_v_predict)
                     sigma_v_model_error_list.append(sigma_v_sigma_model)
-        return sigma_v_name_list, sigma_v_measurement_list, sigma_v_measurement_error_list, sigma_v_model_list, sigma_v_model_error_list
+        return (
+            sigma_v_name_list,
+            sigma_v_measurement_list,
+            sigma_v_measurement_error_list,
+            sigma_v_model_list,
+            sigma_v_model_error_list,
+        )
 
-    def plot_kin_fit(self, cosmo, kwargs_lens, kwargs_kin, color_measurement=None, color_prediction=None):
+    def plot_kin_fit(
+        self,
+        cosmo,
+        kwargs_lens,
+        kwargs_kin,
+        color_measurement=None,
+        color_prediction=None,
+    ):
         """
         plots the prediction and the uncorrelated error bars on the individual lenses
         currently works for likelihood classes 'TDKinGaussian', 'KinGaussian'
@@ -146,26 +209,66 @@ class GoodnessOfFit(object):
         :return: fig, axes of matplotlib instance
         """
         logL = self._sample_likelihood.log_likelihood(cosmo, kwargs_lens, kwargs_kin)
-        print(logL, 'log likelihood')
-        sigma_v_name_list, sigma_v_measurement_list, sigma_v_measurement_error_list, sigma_v_model_list, sigma_v_model_error_list = self.kin_fit(cosmo, kwargs_lens, kwargs_kin)
+        print(logL, "log likelihood")
+        (
+            sigma_v_name_list,
+            sigma_v_measurement_list,
+            sigma_v_measurement_error_list,
+            sigma_v_model_list,
+            sigma_v_model_error_list,
+        ) = self.kin_fit(cosmo, kwargs_lens, kwargs_kin)
 
-        f, ax = plt.subplots(1, 1, figsize=(int(len(sigma_v_name_list)/2), 4))
-        ax.errorbar(np.arange(len(sigma_v_name_list)), sigma_v_measurement_list,
-                    yerr=sigma_v_measurement_error_list, xerr=None, fmt='o',
-                    ecolor=None, elinewidth=None, color=color_measurement,
-                    capsize=5, barsabove=False, lolims=False, uplims=False,
-                    xlolims=False, xuplims=False, errorevery=1, capthick=None, data=None, label='measurement')
-        ax.errorbar(np.arange(len(sigma_v_name_list)), sigma_v_model_list, color=color_prediction,
-                    yerr=sigma_v_model_error_list, xerr=None, fmt='o',
-                    ecolor=None, elinewidth=None, label='prediction', capsize=5)
+        f, ax = plt.subplots(1, 1, figsize=(int(len(sigma_v_name_list) / 2), 4))
+        ax.errorbar(
+            np.arange(len(sigma_v_name_list)),
+            sigma_v_measurement_list,
+            yerr=sigma_v_measurement_error_list,
+            xerr=None,
+            fmt="o",
+            ecolor=None,
+            elinewidth=None,
+            color=color_measurement,
+            capsize=5,
+            barsabove=False,
+            lolims=False,
+            uplims=False,
+            xlolims=False,
+            xuplims=False,
+            errorevery=1,
+            capthick=None,
+            data=None,
+            label="measurement",
+        )
+        ax.errorbar(
+            np.arange(len(sigma_v_name_list)),
+            sigma_v_model_list,
+            color=color_prediction,
+            yerr=sigma_v_model_error_list,
+            xerr=None,
+            fmt="o",
+            ecolor=None,
+            elinewidth=None,
+            label="prediction",
+            capsize=5,
+        )
         ax.set_xticks(ticks=np.arange(len(sigma_v_name_list)))
-        ax.set_xticklabels(labels=sigma_v_name_list, rotation='vertical')
-        ax.set_ylabel(r'$\sigma^{\rm P}$ [km/s]', fontsize=15)
+        ax.set_xticklabels(labels=sigma_v_name_list, rotation="vertical")
+        ax.set_ylabel(r"$\sigma^{\rm P}$ [km/s]", fontsize=15)
         ax.legend()
         return f, ax
 
-    def plot_ifu_fit(self, ax, cosmo, kwargs_lens, kwargs_kin, lens_index, bin_edges, show_legend=True,
-                     color_measurement=None, color_prediction=None):
+    def plot_ifu_fit(
+        self,
+        ax,
+        cosmo,
+        kwargs_lens,
+        kwargs_kin,
+        lens_index,
+        bin_edges,
+        show_legend=True,
+        color_measurement=None,
+        color_prediction=None,
+    ):
         """
         plot an individual IFU data goodness of fit
 
@@ -182,27 +285,50 @@ class GoodnessOfFit(object):
         :return: figure as axes instance
         """
         kwargs_likelihood = self._kwargs_likelihood_list[lens_index]
-        name = kwargs_likelihood.get('name', 'lens ' + str(lens_index))
+        name = kwargs_likelihood.get("name", "lens " + str(lens_index))
         likelihood = self._sample_likelihood._lens_list[lens_index]
 
-        if likelihood.likelihood_type not in ['IFUKinCov', 'DdtHistKin', 'DdtGaussKin']:
-            raise ValueError('likelihood type of lens %s is %s. Must be "IFUKinCov", "DdtHistKin", "DdtGaussKin" '
-                             % (name, likelihood.likelihood_type))
-        sigma_v_measurement, cov_error_measurement, sigma_v_predict_mean, cov_error_predict = likelihood.sigma_v_measured_vs_predict(
-            cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin)
+        if likelihood.likelihood_type not in ["IFUKinCov", "DdtHistKin", "DdtGaussKin"]:
+            raise ValueError(
+                'likelihood type of lens %s is %s. Must be "IFUKinCov", "DdtHistKin", "DdtGaussKin" '
+                % (name, likelihood.likelihood_type)
+            )
+        (
+            sigma_v_measurement,
+            cov_error_measurement,
+            sigma_v_predict_mean,
+            cov_error_predict,
+        ) = likelihood.sigma_v_measured_vs_predict(
+            cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin
+        )
 
         if len(np.atleast_1d(bin_edges)) < 2:
-            bin_edges = np.arange(len(sigma_v_measurement)+1) * bin_edges
-        r_bins = (bin_edges[:-1] + np.diff(bin_edges) / 2)
+            bin_edges = np.arange(len(sigma_v_measurement) + 1) * bin_edges
+        r_bins = bin_edges[:-1] + np.diff(bin_edges) / 2
 
-        ax.errorbar(x=r_bins, y=sigma_v_measurement, xerr=np.diff(bin_edges) / 2.,
-                    yerr=np.sqrt(np.diag(cov_error_measurement)),
-                    fmt='o', label='data', capsize=5, color=color_measurement)
-        ax.errorbar(r_bins, sigma_v_predict_mean, yerr=np.sqrt(np.diag(cov_error_predict)), xerr=np.diff(bin_edges) / 2.,
-                    fmt='o', label='model', capsize=5, color=color_prediction)
+        ax.errorbar(
+            x=r_bins,
+            y=sigma_v_measurement,
+            xerr=np.diff(bin_edges) / 2.0,
+            yerr=np.sqrt(np.diag(cov_error_measurement)),
+            fmt="o",
+            label="data",
+            capsize=5,
+            color=color_measurement,
+        )
+        ax.errorbar(
+            r_bins,
+            sigma_v_predict_mean,
+            yerr=np.sqrt(np.diag(cov_error_predict)),
+            xerr=np.diff(bin_edges) / 2.0,
+            fmt="o",
+            label="model",
+            capsize=5,
+            color=color_prediction,
+        )
         if show_legend is True:
             ax.legend(fontsize=20)
         ax.set_title(name, fontsize=20)
-        ax.set_ylabel(r'$\sigma^{\rm P}$[km/s]', fontsize=20)
-        ax.set_xlabel('radial bin [arcsec]', fontsize=20)
+        ax.set_ylabel(r"$\sigma^{\rm P}$[km/s]", fontsize=20)
+        ax.set_xlabel("radial bin [arcsec]", fontsize=20)
         return ax

--- a/hierarc/Diagnostics/goodness_of_fit.py
+++ b/hierarc/Diagnostics/goodness_of_fit.py
@@ -4,9 +4,7 @@ from hierarc.Likelihood.lens_sample_likelihood import LensSampleLikelihood
 
 
 class GoodnessOfFit(object):
-    """
-    class to manage goodness of fit diagnostics
-    """
+    """Class to manage goodness of fit diagnostics."""
 
     def __init__(self, kwargs_likelihood_list):
         """
@@ -20,10 +18,7 @@ class GoodnessOfFit(object):
         )
 
     def reduced_chi2(self, cosmo, kwargs_lens, kwargs_kin):
-        """
-        reduced chi^2 of fit
-
-        """
+        """Reduced chi^2 of fit."""
         logL = self._sample_likelihood.log_likelihood(cosmo, kwargs_lens, kwargs_kin)
         num_data = self._sample_likelihood.num_data()
         return -logL * 2 / num_data
@@ -37,9 +32,8 @@ class GoodnessOfFit(object):
         color_prediction=None,
         redshift_trend=False,
     ):
-        """
-        plots the prediction and the uncorrelated error bars on the individual lenses
-        currently works for likelihood classes 'TDKinGaussian', 'KinGaussian'
+        """Plots the prediction and the uncorrelated error bars on the individual lenses
+        currently works for likelihood classes 'TDKinGaussian', 'KinGaussian'.
 
         :param cosmo: astropy.cosmology instance
         :param kwargs_lens: lens model parameter keyword arguments
@@ -141,14 +135,14 @@ class GoodnessOfFit(object):
         return f, ax
 
     def kin_fit(self, cosmo, kwargs_lens, kwargs_kin):
-        """
-        plots the prediction and the uncorrelated error bars on the individual lenses
-        currently works for likelihood classes 'TDKinGaussian', 'KinGaussian'
+        """Plots the prediction and the uncorrelated error bars on the individual lenses
+        currently works for likelihood classes 'TDKinGaussian', 'KinGaussian'.
 
         :param cosmo: astropy.cosmology instance
         :param kwargs_lens: lens model parameter keyword arguments
         :param kwargs_kin: kinematics model keyword arguments
-        :return: list of name, measurement, measurement errors, model prediction, model prediction error
+        :return: list of name, measurement, measurement errors, model prediction, model
+            prediction error
         """
 
         sigma_v_name_list = []
@@ -197,9 +191,8 @@ class GoodnessOfFit(object):
         color_measurement=None,
         color_prediction=None,
     ):
-        """
-        plots the prediction and the uncorrelated error bars on the individual lenses
-        currently works for likelihood classes 'TDKinGaussian', 'KinGaussian'
+        """Plots the prediction and the uncorrelated error bars on the individual lenses
+        currently works for likelihood classes 'TDKinGaussian', 'KinGaussian'.
 
         :param cosmo: astropy.cosmology instance
         :param kwargs_lens: lens model parameter keyword arguments
@@ -269,15 +262,16 @@ class GoodnessOfFit(object):
         color_measurement=None,
         color_prediction=None,
     ):
-        """
-        plot an individual IFU data goodness of fit
+        """Plot an individual IFU data goodness of fit.
 
         :param ax: matplotlib axes instance
         :param cosmo: astropy.cosmology instance
         :param kwargs_lens: lens model parameter keyword arguments
         :param kwargs_kin: kinematics model keyword arguments
-        :param lens_index: int, index in kwargs_lens to be plotted (needs to be of type 'IFUKinCov')
-        :param bin_edges: radial bin edges in arc seconds. If number, then uniform bin_edges sampled from 0
+        :param lens_index: int, index in kwargs_lens to be plotted (needs to be of type
+            'IFUKinCov')
+        :param bin_edges: radial bin edges in arc seconds. If number, then uniform
+            bin_edges sampled from 0
         :type bin_edges: numpy array or float.
         :param show_legend: bool, to show legend
         :param color_measurement: color of measurement

--- a/hierarc/LensPosterior/anisotropy_config.py
+++ b/hierarc/LensPosterior/anisotropy_config.py
@@ -5,6 +5,7 @@ class AnisotropyConfig(object):
     """
     class to manage the anisotropy model and parameters for the Posterior processing
     """
+
     def __init__(self, anisotropy_model, r_eff):
         """
 
@@ -14,15 +15,23 @@ class AnisotropyConfig(object):
         self._r_eff = r_eff
         self._anisotropy_model = anisotropy_model
 
-        if self._anisotropy_model == 'OM':
+        if self._anisotropy_model == "OM":
             self._ani_param_array = np.array(
-                [0.1, 0.2, 0.5, 1, 2, 5])  # used for r_ani OsipkovMerritt anisotropy description
-        elif self._anisotropy_model == 'GOM':
-            self._ani_param_array = [np.array([0.1, 0.2, 0.5, 1, 2, 5]), np.array([0, 0.5, 0.8, 1])]
-        elif self._anisotropy_model == 'const':
-            self._ani_param_array = np.linspace(-0.49, 1, 7)  # used for constant anisotropy description
+                [0.1, 0.2, 0.5, 1, 2, 5]
+            )  # used for r_ani OsipkovMerritt anisotropy description
+        elif self._anisotropy_model == "GOM":
+            self._ani_param_array = [
+                np.array([0.1, 0.2, 0.5, 1, 2, 5]),
+                np.array([0, 0.5, 0.8, 1]),
+            ]
+        elif self._anisotropy_model == "const":
+            self._ani_param_array = np.linspace(
+                -0.49, 1, 7
+            )  # used for constant anisotropy description
         else:
-            raise ValueError('anisotropy model %s not supported.' % self._anisotropy_model)
+            raise ValueError(
+                "anisotropy model %s not supported." % self._anisotropy_model
+            )
 
     @property
     def kwargs_anisotropy_base(self):
@@ -30,20 +39,22 @@ class AnisotropyConfig(object):
 
         :return: keyword arguments of base anisotropy model configuration
         """
-        if self._anisotropy_model == 'OM':
+        if self._anisotropy_model == "OM":
             a_ani_0 = 1
             r_ani = a_ani_0 * self._r_eff
-            kwargs_anisotropy_0 = {'r_ani': r_ani}
-        elif self._anisotropy_model == 'GOM':
+            kwargs_anisotropy_0 = {"r_ani": r_ani}
+        elif self._anisotropy_model == "GOM":
             a_ani_0 = 1
             r_ani = a_ani_0 * self._r_eff
             beta_inf_0 = 1
-            kwargs_anisotropy_0 = {'r_ani': r_ani, 'beta_inf': beta_inf_0}
-        elif self._anisotropy_model == 'const':
+            kwargs_anisotropy_0 = {"r_ani": r_ani, "beta_inf": beta_inf_0}
+        elif self._anisotropy_model == "const":
             a_ani_0 = 0.1
-            kwargs_anisotropy_0 = {'beta': a_ani_0}
+            kwargs_anisotropy_0 = {"beta": a_ani_0}
         else:
-            raise ValueError('anisotropy model %s not supported.' % self._anisotropy_model)
+            raise ValueError(
+                "anisotropy model %s not supported." % self._anisotropy_model
+            )
         return kwargs_anisotropy_0
 
     @property
@@ -62,14 +73,16 @@ class AnisotropyConfig(object):
         :return: list of anisotropy keyword arguments, value of anisotropy parameter list
         """
 
-        if self._anisotropy_model == 'OM':
+        if self._anisotropy_model == "OM":
             r_ani = a_ani * self._r_eff
-            kwargs_anisotropy = {'r_ani': r_ani}
-        elif self._anisotropy_model == 'GOM':
+            kwargs_anisotropy = {"r_ani": r_ani}
+        elif self._anisotropy_model == "GOM":
             r_ani = a_ani * self._r_eff
-            kwargs_anisotropy = {'r_ani': r_ani, 'beta_inf': beta_inf}
-        elif self._anisotropy_model == 'const':
-            kwargs_anisotropy = {'beta': a_ani}
+            kwargs_anisotropy = {"r_ani": r_ani, "beta_inf": beta_inf}
+        elif self._anisotropy_model == "const":
+            kwargs_anisotropy = {"beta": a_ani}
         else:
-            raise ValueError('anisotropy model %s not supported.' % self._anisotropy_model)
+            raise ValueError(
+                "anisotropy model %s not supported." % self._anisotropy_model
+            )
         return kwargs_anisotropy

--- a/hierarc/LensPosterior/anisotropy_config.py
+++ b/hierarc/LensPosterior/anisotropy_config.py
@@ -2,9 +2,8 @@ import numpy as np
 
 
 class AnisotropyConfig(object):
-    """
-    class to manage the anisotropy model and parameters for the Posterior processing
-    """
+    """Class to manage the anisotropy model and parameters for the Posterior
+    processing."""
 
     def __init__(self, anisotropy_model, r_eff):
         """

--- a/hierarc/LensPosterior/base_config.py
+++ b/hierarc/LensPosterior/base_config.py
@@ -8,11 +8,31 @@ class BaseLensConfig(TDCosmography, ImageModelPosterior, AnisotropyConfig):
     this class contains and manages the base configurations of the lens posteriors and makes sure that they
     are universally applied consistently through the different likelihood definitions
     """
-    def __init__(self, z_lens, z_source, theta_E, theta_E_error, gamma, gamma_error, r_eff, r_eff_error,
-                 kwargs_aperture, kwargs_seeing, kwargs_numerics_galkin, anisotropy_model,
-                 kwargs_lens_light=None, lens_light_model_list=['HERNQUIST'], MGE_light=False, kwargs_mge_light=None,
-                 hernquist_approx=True, sampling_number=1000, num_psf_sampling=100, num_kin_sampling=1000,
-                 multi_observations=False):
+
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        theta_E,
+        theta_E_error,
+        gamma,
+        gamma_error,
+        r_eff,
+        r_eff_error,
+        kwargs_aperture,
+        kwargs_seeing,
+        kwargs_numerics_galkin,
+        anisotropy_model,
+        kwargs_lens_light=None,
+        lens_light_model_list=["HERNQUIST"],
+        MGE_light=False,
+        kwargs_mge_light=None,
+        hernquist_approx=True,
+        sampling_number=1000,
+        num_psf_sampling=100,
+        num_kin_sampling=1000,
+        multi_observations=False,
+    ):
         """
 
         :param z_lens: lens redshift
@@ -34,18 +54,38 @@ class BaseLensConfig(TDCosmography, ImageModelPosterior, AnisotropyConfig):
         :param hernquist_approx: bool, if True, uses the Hernquist approximation for the light profile
         """
         self._z_lens, self._z_source = z_lens, z_source
-        kwargs_model = {'lens_model_list': ['SPP'], 'lens_light_model_list': lens_light_model_list}
-        TDCosmography.__init__(self, z_lens, z_source, kwargs_model, cosmo_fiducial=None,
-                               lens_model_kinematics_bool=None, light_model_kinematics_bool=None,
-                               kwargs_seeing=kwargs_seeing, kwargs_aperture=kwargs_aperture,
-                               multi_observations=multi_observations)
+        kwargs_model = {
+            "lens_model_list": ["SPP"],
+            "lens_light_model_list": lens_light_model_list,
+        }
+        TDCosmography.__init__(
+            self,
+            z_lens,
+            z_source,
+            kwargs_model,
+            cosmo_fiducial=None,
+            lens_model_kinematics_bool=None,
+            light_model_kinematics_bool=None,
+            kwargs_seeing=kwargs_seeing,
+            kwargs_aperture=kwargs_aperture,
+            multi_observations=multi_observations,
+        )
 
         analytic_kinematics = False
-        self.kinematics_modeling_settings(anisotropy_model, kwargs_numerics_galkin,
-                                          analytic_kinematics=analytic_kinematics,
-                                          Hernquist_approx=hernquist_approx, MGE_light=MGE_light, MGE_mass=False,
-                                          kwargs_mge_light=kwargs_mge_light, sampling_number=sampling_number,
-                                          num_psf_sampling=num_psf_sampling, num_kin_sampling=num_kin_sampling)
+        self.kinematics_modeling_settings(
+            anisotropy_model,
+            kwargs_numerics_galkin,
+            analytic_kinematics=analytic_kinematics,
+            Hernquist_approx=hernquist_approx,
+            MGE_light=MGE_light,
+            MGE_mass=False,
+            kwargs_mge_light=kwargs_mge_light,
+            sampling_number=sampling_number,
+            num_psf_sampling=num_psf_sampling,
+            num_kin_sampling=num_kin_sampling,
+        )
         self._kwargs_lens_light = kwargs_lens_light
-        ImageModelPosterior.__init__(self, theta_E, theta_E_error, gamma, gamma_error, r_eff, r_eff_error)
+        ImageModelPosterior.__init__(
+            self, theta_E, theta_E_error, gamma, gamma_error, r_eff, r_eff_error
+        )
         AnisotropyConfig.__init__(self, anisotropy_model, r_eff)

--- a/hierarc/LensPosterior/base_config.py
+++ b/hierarc/LensPosterior/base_config.py
@@ -4,10 +4,9 @@ from hierarc.LensPosterior.anisotropy_config import AnisotropyConfig
 
 
 class BaseLensConfig(TDCosmography, ImageModelPosterior, AnisotropyConfig):
-    """
-    this class contains and manages the base configurations of the lens posteriors and makes sure that they
-    are universally applied consistently through the different likelihood definitions
-    """
+    """This class contains and manages the base configurations of the lens posteriors
+    and makes sure that they are universally applied consistently through the different
+    likelihood definitions."""
 
     def __init__(
         self,

--- a/hierarc/LensPosterior/ddt_kin_constraints.py
+++ b/hierarc/LensPosterior/ddt_kin_constraints.py
@@ -7,13 +7,38 @@ class DdtKinConstraints(KinConstraints):
     time-delay distance Ddt
     """
 
-    def __init__(self, z_lens, z_source, ddt_samples, ddt_weights, theta_E, theta_E_error, gamma, gamma_error, r_eff,
-                 r_eff_error, sigma_v_measured, kwargs_aperture, kwargs_seeing, kwargs_numerics_galkin,
-                 anisotropy_model, sigma_v_error_independent=None, sigma_v_error_covariant=None,
-                 sigma_v_error_cov_matrix=None,
-                 kwargs_lens_light=None, lens_light_model_list=['HERNQUIST'], MGE_light=False, kwargs_mge_light=None,
-                 hernquist_approx=False, kappa_ext=0, kappa_ext_sigma=0, sampling_number=1000, num_psf_sampling=100,
-                 num_kin_sampling=1000, multi_observations=False):
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        ddt_samples,
+        ddt_weights,
+        theta_E,
+        theta_E_error,
+        gamma,
+        gamma_error,
+        r_eff,
+        r_eff_error,
+        sigma_v_measured,
+        kwargs_aperture,
+        kwargs_seeing,
+        kwargs_numerics_galkin,
+        anisotropy_model,
+        sigma_v_error_independent=None,
+        sigma_v_error_covariant=None,
+        sigma_v_error_cov_matrix=None,
+        kwargs_lens_light=None,
+        lens_light_model_list=["HERNQUIST"],
+        MGE_light=False,
+        kwargs_mge_light=None,
+        hernquist_approx=False,
+        kappa_ext=0,
+        kappa_ext_sigma=0,
+        sampling_number=1000,
+        num_psf_sampling=100,
+        num_kin_sampling=1000,
+        multi_observations=False,
+    ):
         """
 
         :param z_lens: lens redshift
@@ -47,21 +72,33 @@ class DdtKinConstraints(KinConstraints):
         """
         self._ddt_sample, self._ddt_weights = ddt_samples, ddt_weights
         self._kappa_ext_mean, self._kappa_ext_sigma = kappa_ext, kappa_ext_sigma
-        super(DdtKinConstraints, self).__init__(z_lens=z_lens, z_source=z_source, theta_E=theta_E,
-                                                theta_E_error=theta_E_error, gamma=gamma, gamma_error=gamma_error,
-                                                r_eff=r_eff, r_eff_error=r_eff_error, sigma_v_measured=sigma_v_measured,
-                                                kwargs_aperture=kwargs_aperture, kwargs_seeing=kwargs_seeing,
-                                                kwargs_numerics_galkin=kwargs_numerics_galkin,
-                                                anisotropy_model=anisotropy_model,
-                                                sigma_v_error_independent=sigma_v_error_independent,
-                                                sigma_v_error_covariant=sigma_v_error_covariant,
-                                                sigma_v_error_cov_matrix=sigma_v_error_cov_matrix,
-                                                kwargs_lens_light=kwargs_lens_light,
-                                                lens_light_model_list=lens_light_model_list, MGE_light=MGE_light,
-                                                kwargs_mge_light=kwargs_mge_light, hernquist_approx=hernquist_approx,
-                                                sampling_number=sampling_number, num_psf_sampling=num_psf_sampling,
-                                                num_kin_sampling=num_kin_sampling,
-                                                multi_observations=multi_observations)
+        super(DdtKinConstraints, self).__init__(
+            z_lens=z_lens,
+            z_source=z_source,
+            theta_E=theta_E,
+            theta_E_error=theta_E_error,
+            gamma=gamma,
+            gamma_error=gamma_error,
+            r_eff=r_eff,
+            r_eff_error=r_eff_error,
+            sigma_v_measured=sigma_v_measured,
+            kwargs_aperture=kwargs_aperture,
+            kwargs_seeing=kwargs_seeing,
+            kwargs_numerics_galkin=kwargs_numerics_galkin,
+            anisotropy_model=anisotropy_model,
+            sigma_v_error_independent=sigma_v_error_independent,
+            sigma_v_error_covariant=sigma_v_error_covariant,
+            sigma_v_error_cov_matrix=sigma_v_error_cov_matrix,
+            kwargs_lens_light=kwargs_lens_light,
+            lens_light_model_list=lens_light_model_list,
+            MGE_light=MGE_light,
+            kwargs_mge_light=kwargs_mge_light,
+            hernquist_approx=hernquist_approx,
+            sampling_number=sampling_number,
+            num_psf_sampling=num_psf_sampling,
+            num_kin_sampling=num_kin_sampling,
+            multi_observations=multi_observations,
+        )
 
     def hierarchy_configuration(self, num_sample_model=20):
         """
@@ -78,10 +115,18 @@ class DdtKinConstraints(KinConstraints):
         ani_scaling_array_list = self.anisotropy_scaling()
         error_cov_measurement = self.error_cov_measurement
         # configuration keyword arguments for the hierarchical sampling
-        kwargs_likelihood = {'z_lens': self._z_lens, 'z_source': self._z_source, 'likelihood_type': 'DdtHistKin',
-                             'ddt_samples': self._ddt_sample, 'ddt_weights': self._ddt_weights,
-                             'sigma_v_measurement': self._sigma_v_measured, 'anisotropy_model': self._anisotropy_model,
-                             'j_model': j_model_list,  'error_cov_measurement': error_cov_measurement,
-                             'error_cov_j_sqrt': error_cov_j_sqrt, 'ani_param_array': self.ani_param_array,
-                             'ani_scaling_array_list': ani_scaling_array_list}
+        kwargs_likelihood = {
+            "z_lens": self._z_lens,
+            "z_source": self._z_source,
+            "likelihood_type": "DdtHistKin",
+            "ddt_samples": self._ddt_sample,
+            "ddt_weights": self._ddt_weights,
+            "sigma_v_measurement": self._sigma_v_measured,
+            "anisotropy_model": self._anisotropy_model,
+            "j_model": j_model_list,
+            "error_cov_measurement": error_cov_measurement,
+            "error_cov_j_sqrt": error_cov_j_sqrt,
+            "ani_param_array": self.ani_param_array,
+            "ani_scaling_array_list": ani_scaling_array_list,
+        }
         return kwargs_likelihood

--- a/hierarc/LensPosterior/ddt_kin_constraints.py
+++ b/hierarc/LensPosterior/ddt_kin_constraints.py
@@ -2,10 +2,8 @@ from hierarc.LensPosterior.kin_constraints import KinConstraints
 
 
 class DdtKinConstraints(KinConstraints):
-    """
-    class for sampling Ds/Dds posteriors from imaging data and kinematic constraints with additional constraints on the
-    time-delay distance Ddt
-    """
+    """Class for sampling Ds/Dds posteriors from imaging data and kinematic constraints
+    with additional constraints on the time-delay distance Ddt."""
 
     def __init__(
         self,
@@ -101,14 +99,14 @@ class DdtKinConstraints(KinConstraints):
         )
 
     def hierarchy_configuration(self, num_sample_model=20):
-        """
-        routine to configure the likelihood to be used in the hierarchical sampling. In particular, a default
-        configuration is set to compute the Gaussian approximation of Ds/Dds by sampling the posterior and the estimate
-        of the variance of the sample. The anisotropy scaling is then performed. Different anisotropy models are
-        supported.
+        """Routine to configure the likelihood to be used in the hierarchical sampling.
+        In particular, a default configuration is set to compute the Gaussian
+        approximation of Ds/Dds by sampling the posterior and the estimate of the
+        variance of the sample. The anisotropy scaling is then performed. Different
+        anisotropy models are supported.
 
-        :param num_sample_model: number of samples drawn from the lens and light model posterior to compute the dimensionless
-         kinematic component J()
+        :param num_sample_model: number of samples drawn from the lens and light model
+            posterior to compute the dimensionless kinematic component J()
         :return: keyword arguments
         """
         j_model_list, error_cov_j_sqrt = self.model_marginalization(num_sample_model)

--- a/hierarc/LensPosterior/ddt_kin_gauss_constraints.py
+++ b/hierarc/LensPosterior/ddt_kin_gauss_constraints.py
@@ -7,12 +7,38 @@ class DdtGaussKinConstraints(KinConstraints):
     time-delay distance Ddt
     """
 
-    def __init__(self, z_lens, z_source, ddt_mean, ddt_sigma, theta_E, theta_E_error, gamma, gamma_error, r_eff,
-                 r_eff_error, sigma_v_measured, kwargs_aperture, kwargs_seeing, kwargs_numerics_galkin, anisotropy_model,
-                 sigma_v_error_independent=None, sigma_v_error_covariant=None, sigma_v_error_cov_matrix=None,
-                 kwargs_lens_light=None, lens_light_model_list=['HERNQUIST'], MGE_light=False, kwargs_mge_light=None,
-                 hernquist_approx=True, kappa_ext=0, kappa_ext_sigma=0, sampling_number=1000, num_psf_sampling=100,
-                 num_kin_sampling=1000, multi_observations=False):
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        ddt_mean,
+        ddt_sigma,
+        theta_E,
+        theta_E_error,
+        gamma,
+        gamma_error,
+        r_eff,
+        r_eff_error,
+        sigma_v_measured,
+        kwargs_aperture,
+        kwargs_seeing,
+        kwargs_numerics_galkin,
+        anisotropy_model,
+        sigma_v_error_independent=None,
+        sigma_v_error_covariant=None,
+        sigma_v_error_cov_matrix=None,
+        kwargs_lens_light=None,
+        lens_light_model_list=["HERNQUIST"],
+        MGE_light=False,
+        kwargs_mge_light=None,
+        hernquist_approx=True,
+        kappa_ext=0,
+        kappa_ext_sigma=0,
+        sampling_number=1000,
+        num_psf_sampling=100,
+        num_kin_sampling=1000,
+        multi_observations=False,
+    ):
         """
 
         :param z_lens: lens redshift
@@ -45,18 +71,33 @@ class DdtGaussKinConstraints(KinConstraints):
         """
         self._ddt_mean, self._ddt_sigma = ddt_mean, ddt_sigma
         self._kappa_ext_mean, self._kappa_ext_sigma = kappa_ext, kappa_ext_sigma
-        super(DdtGaussKinConstraints, self).__init__(z_lens, z_source, theta_E, theta_E_error, gamma, gamma_error, r_eff,
-                                                     r_eff_error, sigma_v_measured, kwargs_aperture, kwargs_seeing,
-                                                     kwargs_numerics_galkin, anisotropy_model,
-                                                     sigma_v_error_independent=sigma_v_error_independent,
-                                                     sigma_v_error_covariant=sigma_v_error_covariant,
-                                                     sigma_v_error_cov_matrix=sigma_v_error_cov_matrix,
-                                                     kwargs_lens_light=kwargs_lens_light,
-                                                     lens_light_model_list=lens_light_model_list, MGE_light=MGE_light,
-                                                     kwargs_mge_light=kwargs_mge_light, hernquist_approx=hernquist_approx,
-                                                     sampling_number=sampling_number, num_psf_sampling=num_psf_sampling,
-                                                     num_kin_sampling=num_kin_sampling,
-                                                     multi_observations=multi_observations)
+        super(DdtGaussKinConstraints, self).__init__(
+            z_lens,
+            z_source,
+            theta_E,
+            theta_E_error,
+            gamma,
+            gamma_error,
+            r_eff,
+            r_eff_error,
+            sigma_v_measured,
+            kwargs_aperture,
+            kwargs_seeing,
+            kwargs_numerics_galkin,
+            anisotropy_model,
+            sigma_v_error_independent=sigma_v_error_independent,
+            sigma_v_error_covariant=sigma_v_error_covariant,
+            sigma_v_error_cov_matrix=sigma_v_error_cov_matrix,
+            kwargs_lens_light=kwargs_lens_light,
+            lens_light_model_list=lens_light_model_list,
+            MGE_light=MGE_light,
+            kwargs_mge_light=kwargs_mge_light,
+            hernquist_approx=hernquist_approx,
+            sampling_number=sampling_number,
+            num_psf_sampling=num_psf_sampling,
+            num_kin_sampling=num_kin_sampling,
+            multi_observations=multi_observations,
+        )
 
     def hierarchy_configuration(self, num_sample_model=20):
         """
@@ -73,10 +114,18 @@ class DdtGaussKinConstraints(KinConstraints):
         ani_scaling_array_list = self.anisotropy_scaling()
         error_cov_measurement = self.error_cov_measurement
         # configuration keyword arguments for the hierarchical sampling
-        kwargs_likelihood = {'z_lens': self._z_lens, 'z_source': self._z_source, 'likelihood_type': 'DdtGaussKin',
-                             'ddt_mean': self._ddt_mean, 'ddt_sigma': self._ddt_sigma,
-                             'sigma_v_measurement': self._sigma_v_measured, 'anisotropy_model': self._anisotropy_model,
-                             'j_model': j_model_list,  'error_cov_measurement': error_cov_measurement,
-                             'error_cov_j_sqrt': error_cov_j_sqrt, 'ani_param_array': self.ani_param_array,
-                             'ani_scaling_array_list': ani_scaling_array_list}
+        kwargs_likelihood = {
+            "z_lens": self._z_lens,
+            "z_source": self._z_source,
+            "likelihood_type": "DdtGaussKin",
+            "ddt_mean": self._ddt_mean,
+            "ddt_sigma": self._ddt_sigma,
+            "sigma_v_measurement": self._sigma_v_measured,
+            "anisotropy_model": self._anisotropy_model,
+            "j_model": j_model_list,
+            "error_cov_measurement": error_cov_measurement,
+            "error_cov_j_sqrt": error_cov_j_sqrt,
+            "ani_param_array": self.ani_param_array,
+            "ani_scaling_array_list": ani_scaling_array_list,
+        }
         return kwargs_likelihood

--- a/hierarc/LensPosterior/ddt_kin_gauss_constraints.py
+++ b/hierarc/LensPosterior/ddt_kin_gauss_constraints.py
@@ -2,10 +2,8 @@ from hierarc.LensPosterior.kin_constraints import KinConstraints
 
 
 class DdtGaussKinConstraints(KinConstraints):
-    """
-    class for sampling Ds/Dds posteriors from imaging data and kinematic constraints with additional constraints on the
-    time-delay distance Ddt
-    """
+    """Class for sampling Ds/Dds posteriors from imaging data and kinematic constraints
+    with additional constraints on the time-delay distance Ddt."""
 
     def __init__(
         self,
@@ -100,14 +98,14 @@ class DdtGaussKinConstraints(KinConstraints):
         )
 
     def hierarchy_configuration(self, num_sample_model=20):
-        """
-        routine to configure the likelihood to be used in the hierarchical sampling. In particular, a default
-        configuration is set to compute the Gaussian approximation of Ds/Dds by sampling the posterior and the estimate
-        of the variance of the sample. The anisotropy scaling is then performed. Different anisotropy models are
-        supported.
+        """Routine to configure the likelihood to be used in the hierarchical sampling.
+        In particular, a default configuration is set to compute the Gaussian
+        approximation of Ds/Dds by sampling the posterior and the estimate of the
+        variance of the sample. The anisotropy scaling is then performed. Different
+        anisotropy models are supported.
 
-        :param num_sample_model: number of samples drawn from the lens and light model posterior to compute the dimensionless
-         kinematic component J()
+        :param num_sample_model: number of samples drawn from the lens and light model
+            posterior to compute the dimensionless kinematic component J()
         :return: keyword arguments
         """
         j_model_list, error_cov_j_sqrt = self.model_marginalization(num_sample_model)

--- a/hierarc/LensPosterior/imaging_constraints.py
+++ b/hierarc/LensPosterior/imaging_constraints.py
@@ -2,9 +2,7 @@ import numpy as np
 
 
 class ImageModelPosterior(object):
-    """
-    class to manage lens and light model posteriors inferred from imaging data
-    """
+    """Class to manage lens and light model posteriors inferred from imaging data."""
 
     def __init__(self, theta_E, theta_E_error, gamma, gamma_error, r_eff, r_eff_error):
         """

--- a/hierarc/LensPosterior/imaging_constraints.py
+++ b/hierarc/LensPosterior/imaging_constraints.py
@@ -5,6 +5,7 @@ class ImageModelPosterior(object):
     """
     class to manage lens and light model posteriors inferred from imaging data
     """
+
     def __init__(self, theta_E, theta_E_error, gamma, gamma_error, r_eff, r_eff_error):
         """
 
@@ -27,14 +28,18 @@ class ImageModelPosterior(object):
         """
         if no_error is True:
             return self._theta_E, self._gamma, self._r_eff, 1
-        theta_E_draw = np.maximum(np.random.normal(loc=self._theta_E, scale=self._theta_E_error), 0)
+        theta_E_draw = np.maximum(
+            np.random.normal(loc=self._theta_E, scale=self._theta_E_error), 0
+        )
         gamma_draw = np.random.normal(loc=self._gamma, scale=self._gamma_error)
         # distributions are drawn in the range [1, 3)
         # the power-law slope gamma=3 is divergent in mass in the center and values close close to =3 may be unstable
         # to compute the kinematics for.
-        gamma_draw = np.maximum(gamma_draw, 1.)
+        gamma_draw = np.maximum(gamma_draw, 1.0)
         gamma_draw = np.minimum(gamma_draw, 2.999)
         # we make sure no negative r_eff are being sampled
-        delta_r_eff = np.maximum(np.random.normal(loc=1, scale=self._r_eff_error/self._r_eff), 0.001)
+        delta_r_eff = np.maximum(
+            np.random.normal(loc=1, scale=self._r_eff_error / self._r_eff), 0.001
+        )
         r_eff_draw = delta_r_eff * self._r_eff
         return theta_E_draw, gamma_draw, r_eff_draw, delta_r_eff

--- a/hierarc/LensPosterior/kin_constraints.py
+++ b/hierarc/LensPosterior/kin_constraints.py
@@ -8,12 +8,35 @@ class KinConstraints(BaseLensConfig):
     """
     class that manages constraints from Integral Field Unit spectral observations.
     """
-    def __init__(self, z_lens, z_source, theta_E, theta_E_error, gamma, gamma_error, r_eff, r_eff_error,
-                 sigma_v_measured, kwargs_aperture, kwargs_seeing, kwargs_numerics_galkin, anisotropy_model,
-                 sigma_v_error_independent=None, sigma_v_error_covariant=None, sigma_v_error_cov_matrix=None,
-                 kwargs_lens_light=None, lens_light_model_list=['HERNQUIST'],
-                 MGE_light=False, kwargs_mge_light=None, hernquist_approx=True, sampling_number=1000,
-                 num_psf_sampling=100, num_kin_sampling=1000, multi_observations=False):
+
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        theta_E,
+        theta_E_error,
+        gamma,
+        gamma_error,
+        r_eff,
+        r_eff_error,
+        sigma_v_measured,
+        kwargs_aperture,
+        kwargs_seeing,
+        kwargs_numerics_galkin,
+        anisotropy_model,
+        sigma_v_error_independent=None,
+        sigma_v_error_covariant=None,
+        sigma_v_error_cov_matrix=None,
+        kwargs_lens_light=None,
+        lens_light_model_list=["HERNQUIST"],
+        MGE_light=False,
+        kwargs_mge_light=None,
+        hernquist_approx=True,
+        sampling_number=1000,
+        num_psf_sampling=100,
+        num_kin_sampling=1000,
+        multi_observations=False,
+    ):
         """
 
         :param z_lens: lens redshift
@@ -49,13 +72,30 @@ class KinConstraints(BaseLensConfig):
 
         self._kwargs_lens_light = kwargs_lens_light
         self._anisotropy_model = anisotropy_model
-        BaseLensConfig.__init__(self, z_lens, z_source, theta_E, theta_E_error, gamma, gamma_error, r_eff, r_eff_error,
-                                kwargs_aperture, kwargs_seeing, kwargs_numerics_galkin,
-                                anisotropy_model, kwargs_lens_light=kwargs_lens_light,
-                                lens_light_model_list=lens_light_model_list, MGE_light=MGE_light,
-                                kwargs_mge_light=kwargs_mge_light, hernquist_approx=hernquist_approx,
-                                sampling_number=sampling_number, num_psf_sampling=num_psf_sampling,
-                                num_kin_sampling=num_kin_sampling, multi_observations=multi_observations)
+        BaseLensConfig.__init__(
+            self,
+            z_lens,
+            z_source,
+            theta_E,
+            theta_E_error,
+            gamma,
+            gamma_error,
+            r_eff,
+            r_eff_error,
+            kwargs_aperture,
+            kwargs_seeing,
+            kwargs_numerics_galkin,
+            anisotropy_model,
+            kwargs_lens_light=kwargs_lens_light,
+            lens_light_model_list=lens_light_model_list,
+            MGE_light=MGE_light,
+            kwargs_mge_light=kwargs_mge_light,
+            hernquist_approx=hernquist_approx,
+            sampling_number=sampling_number,
+            num_psf_sampling=num_psf_sampling,
+            num_kin_sampling=num_kin_sampling,
+            multi_observations=multi_observations,
+        )
 
     def j_kin_draw(self, kwargs_anisotropy, no_error=False):
         """
@@ -65,20 +105,29 @@ class KinConstraints(BaseLensConfig):
         :param no_error: bool, if True, does not render from the uncertainty but uses the mean values instead
         :return: dimensionless kinematic component J() Birrer et al. 2016, 2019
         """
-        theta_E_draw, gamma_draw, r_eff_draw, delta_r_eff = self.draw_lens(no_error=no_error)
-        kwargs_lens = [{'theta_E': theta_E_draw, 'gamma': gamma_draw, 'center_x': 0, 'center_y': 0}]
+        theta_E_draw, gamma_draw, r_eff_draw, delta_r_eff = self.draw_lens(
+            no_error=no_error
+        )
+        kwargs_lens = [
+            {"theta_E": theta_E_draw, "gamma": gamma_draw, "center_x": 0, "center_y": 0}
+        ]
         if self._kwargs_lens_light is None:
-            kwargs_light = [{'Rs': r_eff_draw * 0.551, 'amp': 1.}]
+            kwargs_light = [{"Rs": r_eff_draw * 0.551, "amp": 1.0}]
         else:
             kwargs_light = copy.deepcopy(self._kwargs_lens_light)
             for kwargs in kwargs_light:
-                if 'Rs' in kwargs:
-                    kwargs['Rs'] *= delta_r_eff
-                if 'R_sersic' in kwargs:
-                    kwargs['R_sersic'] *= delta_r_eff
-        j_kin = self.velocity_dispersion_map_dimension_less(kwargs_lens=kwargs_lens, kwargs_lens_light=kwargs_light,
-                                                            kwargs_anisotropy=kwargs_anisotropy, r_eff=r_eff_draw,
-                                                            theta_E=theta_E_draw, gamma=gamma_draw)
+                if "Rs" in kwargs:
+                    kwargs["Rs"] *= delta_r_eff
+                if "R_sersic" in kwargs:
+                    kwargs["R_sersic"] *= delta_r_eff
+        j_kin = self.velocity_dispersion_map_dimension_less(
+            kwargs_lens=kwargs_lens,
+            kwargs_lens_light=kwargs_light,
+            kwargs_anisotropy=kwargs_anisotropy,
+            r_eff=r_eff_draw,
+            theta_E=theta_E_draw,
+            gamma=gamma_draw,
+        )
         return j_kin
 
     def hierarchy_configuration(self, num_sample_model=20):
@@ -97,11 +146,18 @@ class KinConstraints(BaseLensConfig):
         ani_scaling_array_list = self.anisotropy_scaling()
         error_cov_measurement = self.error_cov_measurement
         # configuration keyword arguments for the hierarchical sampling
-        kwargs_likelihood = {'z_lens': self._z_lens, 'z_source': self._z_source, 'likelihood_type': 'IFUKinCov',
-                             'sigma_v_measurement': self._sigma_v_measured, 'anisotropy_model': self._anisotropy_model,
-                             'j_model': j_model_list,  'error_cov_measurement': error_cov_measurement,
-                             'error_cov_j_sqrt': error_cov_j_sqrt, 'ani_param_array': self.ani_param_array,
-                             'ani_scaling_array_list': ani_scaling_array_list}
+        kwargs_likelihood = {
+            "z_lens": self._z_lens,
+            "z_source": self._z_source,
+            "likelihood_type": "IFUKinCov",
+            "sigma_v_measurement": self._sigma_v_measured,
+            "anisotropy_model": self._anisotropy_model,
+            "j_model": j_model_list,
+            "error_cov_measurement": error_cov_measurement,
+            "error_cov_j_sqrt": error_cov_j_sqrt,
+            "ani_param_array": self.ani_param_array,
+            "ani_scaling_array_list": ani_scaling_array_list,
+        }
         return kwargs_likelihood
 
     def model_marginalization(self, num_sample_model=20):
@@ -112,7 +168,9 @@ class KinConstraints(BaseLensConfig):
         :return: J() as array for each measurement prediction, covariance matrix in sqrt(J)
         """
         num_data = len(self._sigma_v_measured)
-        j_kin_matrix = np.zeros((num_sample_model, num_data))  # matrix that contains the sampled J() distribution
+        j_kin_matrix = np.zeros(
+            (num_sample_model, num_data)
+        )  # matrix that contains the sampled J() distribution
         for i in range(num_sample_model):
             j_kin = self.j_kin_draw(self.kwargs_anisotropy_base, no_error=False)
             j_kin_matrix[i, :] = j_kin
@@ -131,12 +189,21 @@ class KinConstraints(BaseLensConfig):
         :return: nxn matrix of the error covariances in the velocity dispersion measurements (km/s)^2
         """
         if self._sigma_v_error_cov_matrix is None:
-            if self._sigma_v_error_independent is None or self._sigma_v_error_covariant is None:
-                raise ValueError('sigma_v_error_independent and sigma_v_error_covariant need to be provided as arrays '
-                                 'of the same length as sigma_v_measurement.')
-            error_covariance_array = np.ones_like(self._sigma_v_error_independent) * self._sigma_v_error_covariant
-            error_cov_measurement = np.outer(error_covariance_array, error_covariance_array) + np.diag(
-                self._sigma_v_error_independent ** 2)
+            if (
+                self._sigma_v_error_independent is None
+                or self._sigma_v_error_covariant is None
+            ):
+                raise ValueError(
+                    "sigma_v_error_independent and sigma_v_error_covariant need to be provided as arrays "
+                    "of the same length as sigma_v_measurement."
+                )
+            error_covariance_array = (
+                np.ones_like(self._sigma_v_error_independent)
+                * self._sigma_v_error_covariant
+            )
+            error_cov_measurement = np.outer(
+                error_covariance_array, error_covariance_array
+            ) + np.diag(self._sigma_v_error_independent**2)
             return error_cov_measurement
         else:
             return self._sigma_v_error_cov_matrix
@@ -158,16 +225,22 @@ class KinConstraints(BaseLensConfig):
         """
         num_data = len(self._sigma_v_measured)
 
-        if self._anisotropy_model == 'GOM':
-            ani_scaling_array_list = [np.zeros((len(self.ani_param_array[0]), len(self.ani_param_array[1]))) for _ in
-                                      range(num_data)]
+        if self._anisotropy_model == "GOM":
+            ani_scaling_array_list = [
+                np.zeros((len(self.ani_param_array[0]), len(self.ani_param_array[1])))
+                for _ in range(num_data)
+            ]
             for i, a_ani in enumerate(self.ani_param_array[0]):
                 for j, beta_inf in enumerate(self.ani_param_array[1]):
-                    kwargs_anisotropy = self.anisotropy_kwargs(a_ani=a_ani, beta_inf=beta_inf)
+                    kwargs_anisotropy = self.anisotropy_kwargs(
+                        a_ani=a_ani, beta_inf=beta_inf
+                    )
                     j_kin_ani = self.j_kin_draw(kwargs_anisotropy, no_error=True)
                     for k, j_kin in enumerate(j_kin_ani):
-                        ani_scaling_array_list[k][i, j] = j_kin / j_ani_0[k]  # perhaps change the order
-        elif self._anisotropy_model in ['OM', 'const']:
+                        ani_scaling_array_list[k][i, j] = (
+                            j_kin / j_ani_0[k]
+                        )  # perhaps change the order
+        elif self._anisotropy_model in ["OM", "const"]:
             ani_scaling_array_list = [[] for _ in range(num_data)]
             for a_ani in self.ani_param_array:
                 kwargs_anisotropy = self.anisotropy_kwargs(a_ani)
@@ -175,5 +248,5 @@ class KinConstraints(BaseLensConfig):
                 for i, j_kin in enumerate(j_kin_ani):
                     ani_scaling_array_list[i].append(j_kin / j_ani_0[i])
         else:
-            raise ValueError('anisotropy model %s not valid.' % self._anisotropy_model)
+            raise ValueError("anisotropy model %s not valid." % self._anisotropy_model)
         return ani_scaling_array_list

--- a/hierarc/LensPosterior/kin_constraints.py
+++ b/hierarc/LensPosterior/kin_constraints.py
@@ -5,9 +5,7 @@ from hierarc.LensPosterior.base_config import BaseLensConfig
 
 
 class KinConstraints(BaseLensConfig):
-    """
-    class that manages constraints from Integral Field Unit spectral observations.
-    """
+    """Class that manages constraints from Integral Field Unit spectral observations."""
 
     def __init__(
         self,
@@ -98,11 +96,11 @@ class KinConstraints(BaseLensConfig):
         )
 
     def j_kin_draw(self, kwargs_anisotropy, no_error=False):
-        """
-        one simple sampling realization of the dimensionless kinematics of the model
+        """One simple sampling realization of the dimensionless kinematics of the model.
 
         :param kwargs_anisotropy: keyword argument of anisotropy setting
-        :param no_error: bool, if True, does not render from the uncertainty but uses the mean values instead
+        :param no_error: bool, if True, does not render from the uncertainty but uses
+            the mean values instead
         :return: dimensionless kinematic component J() Birrer et al. 2016, 2019
         """
         theta_E_draw, gamma_draw, r_eff_draw, delta_r_eff = self.draw_lens(
@@ -131,14 +129,14 @@ class KinConstraints(BaseLensConfig):
         return j_kin
 
     def hierarchy_configuration(self, num_sample_model=20):
-        """
-        routine to configure the likelihood to be used in the hierarchical sampling. In particular, a default
-        configuration is set to compute the Gaussian approximation of Ds/Dds by sampling the posterior and the estimate
-        of the variance of the sample. The anisotropy scaling is then performed. Different anisotropy models are
-        supported.
+        """Routine to configure the likelihood to be used in the hierarchical sampling.
+        In particular, a default configuration is set to compute the Gaussian
+        approximation of Ds/Dds by sampling the posterior and the estimate of the
+        variance of the sample. The anisotropy scaling is then performed. Different
+        anisotropy models are supported.
 
-        :param num_sample_model: number of samples drawn from the lens and light model posterior to compute the
-         dimensionless kinematic component J()
+        :param num_sample_model: number of samples drawn from the lens and light model
+            posterior to compute the dimensionless kinematic component J()
         :return: keyword arguments
         """
 
@@ -181,12 +179,13 @@ class KinConstraints(BaseLensConfig):
 
     @property
     def error_cov_measurement(self):
-        """
-        error covariance matrix of the measured velocity dispersion data points
-        This is either calculated from the diagonal 'sigma_v_error_independent' and the off-diagonal
-        'sigma_v_error_covariant' terms, or directly from the 'sigma_v_error_cov_matrix' if provided.
+        """Error covariance matrix of the measured velocity dispersion data points This
+        is either calculated from the diagonal 'sigma_v_error_independent' and the off-
+        diagonal 'sigma_v_error_covariant' terms, or directly from the
+        'sigma_v_error_cov_matrix' if provided.
 
-        :return: nxn matrix of the error covariances in the velocity dispersion measurements (km/s)^2
+        :return: nxn matrix of the error covariances in the velocity dispersion
+            measurements (km/s)^2
         """
         if self._sigma_v_error_cov_matrix is None:
             if (
@@ -217,11 +216,11 @@ class KinConstraints(BaseLensConfig):
         return self._anisotropy_scaling_relative(j_ani_0)
 
     def _anisotropy_scaling_relative(self, j_ani_0):
-        """
-        anisotropy scaling relative to a default J prediction
+        """Anisotropy scaling relative to a default J prediction.
 
         :param j_ani_0: default J() prediction for default anisotropy
-        :return: list of arrays (for the number of measurements) according to anisotropy scaling
+        :return: list of arrays (for the number of measurements) according to anisotropy
+            scaling
         """
         num_data = len(self._sigma_v_measured)
 

--- a/hierarc/Likelihood/KDELikelihood/chain.py
+++ b/hierarc/Likelihood/KDELikelihood/chain.py
@@ -1,4 +1,4 @@
-__author__ = 'martin-millon'
+__author__ = "martin-millon"
 
 import glob
 import os
@@ -11,7 +11,16 @@ class Chain(object):
     Chain class to have a convenient way to manipulate posteriors distributions of some experiments.
     """
 
-    def __init__(self, kw, probe, params, default_weights, cosmology, loglsamples=None, rescale=True):
+    def __init__(
+        self,
+        kw,
+        probe,
+        params,
+        default_weights,
+        cosmology,
+        loglsamples=None,
+        rescale=True,
+    ):
         """
 
         :param kw: (str). Planck base cosmology keyword. For example, "base" or "base_omegak". See https://wiki.cosmos.esa.int/planck-legacy-archive/index.php/Cosmological_Parameters.
@@ -30,7 +39,7 @@ class Chain(object):
         self.loglsamples = loglsamples
         self.rescale = rescale
         if self.rescale:
-            self.rescale_dic = {'rescaled': False}
+            self.rescale_dic = {"rescaled": False}
             self.rescale_to_unity()
 
     def __str__(self):
@@ -63,10 +72,10 @@ class Chain(object):
         :param nsamples: (int). Number of samples in the Chain. If None, it will take the same number of samples as for the other parameters
         :param verbose: (bool).
         """
-        assert (len(self.params[param]) == 0)
+        assert len(self.params[param]) == 0
         if nsamples is None:
             lp = self.list_params()
-            assert (len(lp) > 0)
+            assert len(lp) > 0
             nsamples = len(self.params[lp[0]])
 
         self.params[param] = np.ones(nsamples) * default_val
@@ -83,13 +92,13 @@ class Chain(object):
         """
 
         lp = self.list_params()
-        assert (len(lp) > 0)
+        assert len(lp) > 0
         nsamples = len(self.params[lp[0]])
-        assert (len(default_array) == nsamples)
+        assert len(default_array) == nsamples
 
         if param not in self.params.keys():
             if verbose:
-                print('Creating a new parameter.')
+                print("Creating a new parameter.")
 
         self.params[param] = default_array
         if verbose:
@@ -109,17 +118,17 @@ class Chain(object):
 
         :param verbose: (bool).
         """
-        if self.rescale_dic['rescaled']:
-            raise RuntimeError('Your data are already rescaled!')
+        if self.rescale_dic["rescaled"]:
+            raise RuntimeError("Your data are already rescaled!")
         else:
             for p in self.params.keys():
                 max, min = np.max(self.params[p]), np.min(self.params[p])
-                self.params[p] = ((self.params[p] - min) / (max - min))
+                self.params[p] = (self.params[p] - min) / (max - min)
                 self.rescale_dic[p] = [max, min]
 
                 if verbose:
                     print("Rescaled parameter %s between 0 and 1" % p)
-            self.rescale_dic['rescaled'] = True
+            self.rescale_dic["rescaled"] = True
 
     def rescale_from_unity(self, verbose=False):
         """
@@ -127,8 +136,10 @@ class Chain(object):
 
         :param verbose: (bool).
         """
-        if not self.rescale_dic['rescaled']:
-            raise RuntimeError('Your data are not rescaled, call rescale_to_unity() first')
+        if not self.rescale_dic["rescaled"]:
+            raise RuntimeError(
+                "Your data are not rescaled, call rescale_to_unity() first"
+            )
         else:
             for p in self.params.keys():
                 max, min = self.rescale_dic[p]
@@ -136,7 +147,7 @@ class Chain(object):
                 if verbose:
                     print("Rescaled parameter %s to original scale." % p)
 
-            self.rescale_dic['rescaled'] = False
+            self.rescale_dic["rescaled"] = False
 
 
 def import_Planck_chain(datapath, kw, probe, params, cosmology, rescale=True):
@@ -152,11 +163,15 @@ def import_Planck_chain(datapath, kw, probe, params, cosmology, rescale=True):
     :return: Chain object.
     """
     # the planck chains are usually split in four files
-    chainspaths = glob.glob("%s/%s_%s_?.txt" % (os.path.join(datapath, kw, probe), kw, probe))
+    chainspaths = glob.glob(
+        "%s/%s_%s_?.txt" % (os.path.join(datapath, kw, probe), kw, probe)
+    )
     allchainspath = "%s/%s_%s-all.txt" % (os.path.join(datapath, kw, probe), kw, probe)
 
     # read paramfiles and collect indexes of the interesting cosmological parameters
-    params_all = open("%s/%s_%s.paramnames" % (os.path.join(datapath, kw, probe), kw, probe)).readlines()
+    params_all = open(
+        "%s/%s_%s.paramnames" % (os.path.join(datapath, kw, probe), kw, probe)
+    ).readlines()
 
     params_values, params_index = {}, {}
     for p in params:
@@ -167,35 +182,37 @@ def import_Planck_chain(datapath, kw, probe, params, cosmology, rescale=True):
     # Here, we browse the chains params, looking for the parameters of interest.
     # We corresponding index is +2, since the first two parameters of each sample (weights ) are not in params
     for ind, line in enumerate(params_all):
-        if 'omegal*\t\\Omega_\\Lambda\n' in line:
+        if "omegal*\t\\Omega_\\Lambda\n" in line:
             params_index["ol"] = ind + 2
 
-        elif 'ns\tn_s\n' in line:
+        elif "ns\tn_s\n" in line:
             params_index["ns"] = ind + 2
 
-        elif 'H0*\tH_0\n' in line:
+        elif "H0*\tH_0\n" in line:
             params_index["h0"] = ind + 2
 
-        elif 'omegam*\t\\Omega_m\n' in line:
+        elif "omegam*\t\\Omega_m\n" in line:
             params_index["om"] = ind + 2
 
-        elif 'mnu\t\\Sigma m_\\nu\n' in line:  # pragma: no cover
+        elif "mnu\t\\Sigma m_\\nu\n" in line:  # pragma: no cover
             params_index["mnu"] = ind + 2
 
-        elif 'nnu\tN_{eff}\n' in line:  # pragma: no cover
+        elif "nnu\tN_{eff}\n" in line:  # pragma: no cover
             params_index["nnu"] = ind + 2
 
-        elif 'omegak\t\\Omega_K\n' in line:  # pragma: no cover
+        elif "omegak\t\\Omega_K\n" in line:  # pragma: no cover
             params_index["ok"] = ind + 2
 
-        elif 'w\tw\n' in line:  # pragma: no cover
+        elif "w\tw\n" in line:  # pragma: no cover
             params_index["w"] = ind + 2
             params_index["w0"] = ind + 2
 
-        elif 'wa\tw_a\n' in line:  # pragma: no cover
+        elif "wa\tw_a\n" in line:  # pragma: no cover
             params_index["wa"] = ind + 2
 
-        elif 'meffsterile\tm_{\\nu,{\\rm{sterile}}}^{\\rm{eff}}\n' in line:  # pragma: no cover
+        elif (
+            "meffsterile\tm_{\\nu,{\\rm{sterile}}}^{\\rm{eff}}\n" in line
+        ):  # pragma: no cover
             params_index["meffsterile"] = ind + 2
 
     default_weights = []
@@ -206,8 +223,12 @@ def import_Planck_chain(datapath, kw, probe, params, cosmology, rescale=True):
             for p in params:
                 if params_index[p] is not None:
                     params_values[p] += [s[params_index[p]] for s in samples]
-            default_weights += [s[0] for s in samples]  # weights are always the first element of a chain
-            logl_samples += [s[1] for s in samples]  # loglikelihood is the second element
+            default_weights += [
+                s[0] for s in samples
+            ]  # weights are always the first element of a chain
+            logl_samples += [
+                s[1] for s in samples
+            ]  # loglikelihood is the second element
 
     # fallback to numpy arrays with floats...should be default but is not...?
     for p in params:
@@ -216,8 +237,15 @@ def import_Planck_chain(datapath, kw, probe, params, cosmology, rescale=True):
     default_weights = np.array([float(v) for v in default_weights])
     logl_samples = np.array([float(v) for v in logl_samples])
 
-    return Chain(kw=kw, probe=probe, params=params_values, default_weights=default_weights, cosmology=cosmology,
-                 loglsamples=logl_samples, rescale=rescale)
+    return Chain(
+        kw=kw,
+        probe=probe,
+        params=params_values,
+        default_weights=default_weights,
+        cosmology=cosmology,
+        loglsamples=logl_samples,
+        rescale=rescale,
+    )
 
 
 def rescale_vector_from_unity(vector, rescale_dic, keys):
@@ -246,5 +274,5 @@ def rescale_vector_to_unity(vector, rescale_dic, keys):
     """
     for i, key in enumerate(keys):
         max, min = rescale_dic[key]
-        vector[:, i] = ((vector[:, i] - min) / (max - min))
+        vector[:, i] = (vector[:, i] - min) / (max - min)
     return vector

--- a/hierarc/Likelihood/KDELikelihood/chain.py
+++ b/hierarc/Likelihood/KDELikelihood/chain.py
@@ -7,9 +7,8 @@ import numpy as np
 
 
 class Chain(object):
-    """
-    Chain class to have a convenient way to manipulate posteriors distributions of some experiments.
-    """
+    """Chain class to have a convenient way to manipulate posteriors distributions of
+    some experiments."""
 
     def __init__(
         self,
@@ -43,33 +42,28 @@ class Chain(object):
             self.rescale_to_unity()
 
     def __str__(self):
-        """
-        Print the identifier of the Chain.
+        """Print the identifier of the Chain.
+
         :return:
         """
         return "%s_%s" % (self.kw, self.probe)
 
     def list_params(self):
-        """
-        List the cosmo parameters that are not empty
-        :return: List of parameter name
-        """
+        """List the cosmo parameters that are not empty :return: List of parameter
+        name."""
         return [p for p in self.params.keys() if len(self.params[p]) > 0]
 
     def list_weights(self):
-        """
-        List the existing weights
-        :return: Array of weights
-        """
+        """List the existing weights :return: Array of weights."""
         return [w for w in self.weights.keys() if len(self.weights[w]) > 0]
 
     def fill_default(self, param, default_val, nsamples=None, verbose=False):
-        """
-        Fill an empty default param with a default value
+        """Fill an empty default param with a default value.
 
         :param param: (string) Name of the parameter to fill with default value
         :param default_val: (float). Default value.
-        :param nsamples: (int). Number of samples in the Chain. If None, it will take the same number of samples as for the other parameters
+        :param nsamples: (int). Number of samples in the Chain. If None, it will take
+            the same number of samples as for the other parameters
         :param verbose: (bool).
         """
         assert len(self.params[param]) == 0
@@ -83,11 +77,11 @@ class Chain(object):
             print("filled %s with value %f" % (param, default_val))
 
     def fill_default_array(self, param, default_array, verbose=False):
-        """
-        Fill an empty default param with a default array
+        """Fill an empty default param with a default array.
 
         :param param: (str). Name of the parameter
-        :param default_array: (numpy array). Must have the same dimension as the samples.
+        :param default_array: (numpy array). Must have the same dimension as the
+            samples.
         :param verbose: (bool).
         """
 
@@ -105,16 +99,14 @@ class Chain(object):
             print("filled %s" % (param))
 
     def create_param(self, param_key):
-        """
-        Add a new parameter to the Chain
+        """Add a new parameter to the Chain.
 
         :param param_key: (str). Parameter name.
         """
         self.params[param_key] = []
 
     def rescale_to_unity(self, verbose=False):
-        """
-        Rescale all parameter chains between 0 and 1.
+        """Rescale all parameter chains between 0 and 1.
 
         :param verbose: (bool).
         """
@@ -131,8 +123,7 @@ class Chain(object):
             self.rescale_dic["rescaled"] = True
 
     def rescale_from_unity(self, verbose=False):
-        """
-        Rescale all parameter chains to their original values.
+        """Rescale all parameter chains to their original values.
 
         :param verbose: (bool).
         """
@@ -151,15 +142,21 @@ class Chain(object):
 
 
 def import_Planck_chain(datapath, kw, probe, params, cosmology, rescale=True):
-    """
-    Special function to parse Planck files. Return a Chain object.
+    """Special function to parse Planck files. Return a Chain object.
 
+    :param datapath: (str). Path to the Planck chain :param kw: (str). Planck base
+    cosmology keyword. For example, "base" or "base_omegak". See
+    https://wiki.cosmos.esa.int/planck-legacy-archive/index.php/Cosmological_Parameters.
     :param datapath: (str). Path to the Planck chain
-    :param kw: (str). Planck base cosmology keyword. For example, "base" or "base_omegak". See https://wiki.cosmos.esa.int/planck-legacy-archive/index.php/Cosmological_Parameters.
-    :param probe: (str). Planck probe combination. For example, "plikHM_TTTEEE_lowl_lowE" for default Planck results
+    :param kw: (str). Planck base cosmology keyword. For example, "base" or
+        "base_omegak". See https://wiki.cosmos.esa.int/planck-legacy-
+        archive/index.php/Cosmological_Parameters.
+    :param probe: (str). Planck probe combination. For example,
+        "plikHM_TTTEEE_lowl_lowE" for default Planck results
     :param params: (list). List of cosmological parameters. ["h0", "om"] for FLCDM.
     :param cosmology: (str). Astropy cosmology
-    :param rescale: (bool). Rescale the chains between 0 and 1 for all parameters. This is absolutely necessary if you want to evaluate a KDE on these chains.
+    :param rescale: (bool). Rescale the chains between 0 and 1 for all parameters. This
+        is absolutely necessary if you want to evaluate a KDE on these chains.
     :return: Chain object.
     """
     # the planck chains are usually split in four files
@@ -249,12 +246,13 @@ def import_Planck_chain(datapath, kw, probe, params, cosmology, rescale=True):
 
 
 def rescale_vector_from_unity(vector, rescale_dic, keys):
-    """
-    Restore the original scaling of the samples, given the value in `rescale_dic`.
+    """Restore the original scaling of the samples, given the value in `rescale_dic`.
 
     :param vector: (numpy array). Vector to be rescaled.
-    :param rescale_dic: (dictionnary). Contains the min and max value for each parameters.
-    :param keys: (list). Contain the name of the parameter to be rescaled. all keys must be in the rescale_dic.
+    :param rescale_dic: (dictionnary). Contains the min and max value for each
+        parameters.
+    :param keys: (list). Contain the name of the parameter to be rescaled. all keys must
+        be in the rescale_dic.
     :return:
     """
     for i, key in enumerate(keys):
@@ -264,12 +262,13 @@ def rescale_vector_from_unity(vector, rescale_dic, keys):
 
 
 def rescale_vector_to_unity(vector, rescale_dic, keys):
-    """
-    Rescale a vector accroding to the min adn max value provided in rescale_dic
+    """Rescale a vector accroding to the min adn max value provided in rescale_dic.
 
     :param vector: (numpy array). Vector to be rescaled.
-    :param rescale_dic: (dictionnary). Contains the min and max value for each parameters.
-    :param keys: Contain the name of the parameter to be rescaled. all keys must be in the rescale_dic.
+    :param rescale_dic: (dictionnary). Contains the min and max value for each
+        parameters.
+    :param keys: Contain the name of the parameter to be rescaled. all keys must be in
+        the rescale_dic.
     :return:
     """
     for i, key in enumerate(keys):

--- a/hierarc/Likelihood/KDELikelihood/kde_likelihood.py
+++ b/hierarc/Likelihood/KDELikelihood/kde_likelihood.py
@@ -1,4 +1,4 @@
-__author__ = 'martin-millon'
+__author__ = "martin-millon"
 
 import os
 
@@ -9,7 +9,8 @@ from sklearn.neighbors import KernelDensity
 import hierarc
 
 LIKELIHOOD_TYPES = ["kde_hist_nd", "kde_full"]
-_PATH_2_PLANCKDATA = os.path.join(os.path.dirname(hierarc.__file__), 'Data', 'Planck')
+_PATH_2_PLANCKDATA = os.path.join(os.path.dirname(hierarc.__file__), "Data", "Planck")
+
 
 class KDELikelihood(object):
     """
@@ -21,10 +22,15 @@ class KDELikelihood(object):
 
     """
 
-    def __init__(self, chain, likelihood_type="kde_hist_nd",
-                 weight_type='default',
-                 kde_kernel='gaussian',
-                 bandwidth=0.01, nbins_hist=30):
+    def __init__(
+        self,
+        chain,
+        likelihood_type="kde_hist_nd",
+        weight_type="default",
+        kde_kernel="gaussian",
+        bandwidth=0.01,
+        nbins_hist=30,
+    ):
         """
 
         :param chain: (Likelihood.chain.Chain). Chain object to be evaluated with a kernel density estimator
@@ -48,15 +54,22 @@ class KDELikelihood(object):
         Initialisation of the KDE, depending on loglikelihood_type.
         """
         if self.loglikelihood_type == "kde_full":
-            self.kde = self.init_kernel_full(kde_kernel=self.kde_kernel, bandwidth=self.bandwidth)
+            self.kde = self.init_kernel_full(
+                kde_kernel=self.kde_kernel, bandwidth=self.bandwidth
+            )
             self.loglikelihood = self.kdelikelihood()
         elif self.loglikelihood_type == "kde_hist_nd":
-            self.kde = self.init_kernel_kdelikelihood_hist_nd(kde_kernel=self.kde_kernel, bandwidth=self.bandwidth,
-                                                              nbins_hist=self.nbins_hist)
+            self.kde = self.init_kernel_kdelikelihood_hist_nd(
+                kde_kernel=self.kde_kernel,
+                bandwidth=self.bandwidth,
+                nbins_hist=self.nbins_hist,
+            )
             self.loglikelihood = self.kdelikelihood()
         else:
             raise ValueError(
-                'likelihood_type %s not supported! Supported are %s.' % (likelihood_type, LIKELIHOOD_TYPES))
+                "likelihood_type %s not supported! Supported are %s."
+                % (likelihood_type, LIKELIHOOD_TYPES)
+            )
 
     def kdelikelihood(self):
         """
@@ -82,8 +95,9 @@ class KDELikelihood(object):
         :return: scikit-learn KernelDensity
         """
         data = pd.DataFrame.from_dict(self.chain.params)
-        kde = KernelDensity(kernel=kde_kernel, bandwidth=bandwidth).fit(data.values,
-                                                                        sample_weight=self.chain.weights[self.weight_type])
+        kde = KernelDensity(kernel=kde_kernel, bandwidth=bandwidth).fit(
+            data.values, sample_weight=self.chain.weights[self.weight_type]
+        )
         return kde
 
     def init_kernel_kdelikelihood_hist_nd(self, kde_kernel, bandwidth, nbins_hist):
@@ -99,7 +113,9 @@ class KDELikelihood(object):
         :param nbins_hist: (float). Number of bins to use before fitting KDE. Used only if likelihood_type = 'kde_hist_nd'.
         :return: scikit-learn KernelDensity
         """
-        samples = np.asarray([self.chain.params[keys] for keys in self.chain.params.keys()])
+        samples = np.asarray(
+            [self.chain.params[keys] for keys in self.chain.params.keys()]
+        )
         hist, edges = np.histogramdd(samples.T, bins=nbins_hist)
         edges = np.asarray(edges)
 
@@ -107,10 +123,12 @@ class KDELikelihood(object):
         ndim = len(self.chain.params.keys())
         keys = list(self.chain.params.keys())
         for i, key in enumerate(keys):
-            dic[key] = [(p + edges[i, j + 1]) / 2.0 for j, p in enumerate(edges[i, :-1])]
+            dic[key] = [
+                (p + edges[i, j + 1]) / 2.0 for j, p in enumerate(edges[i, :-1])
+            ]
 
         # for some reasons that are not obvious, ravel do not reverse meshgrid, indexing argument is really needed here
-        mesh_tuple = np.meshgrid(*[dic[key] for key in keys], indexing='ij')
+        mesh_tuple = np.meshgrid(*[dic[key] for key in keys], indexing="ij")
         meshdic = []
         for i, key in enumerate(keys):
             meshdic.append(mesh_tuple[i].flatten())
@@ -123,5 +141,7 @@ class KDELikelihood(object):
         kde_weights = kde_weights[kde_weights > 0]
 
         # fit the KDE
-        kde = KernelDensity(kernel=kde_kernel, bandwidth=bandwidth).fit(kde_bins.values, sample_weight=kde_weights)
+        kde = KernelDensity(kernel=kde_kernel, bandwidth=bandwidth).fit(
+            kde_bins.values, sample_weight=kde_weights
+        )
         return kde

--- a/hierarc/Likelihood/KDELikelihood/kde_likelihood.py
+++ b/hierarc/Likelihood/KDELikelihood/kde_likelihood.py
@@ -50,9 +50,7 @@ class KDELikelihood(object):
         self.init_loglikelihood()
 
     def init_loglikelihood(self):
-        """
-        Initialisation of the KDE, depending on loglikelihood_type.
-        """
+        """Initialisation of the KDE, depending on loglikelihood_type."""
         if self.loglikelihood_type == "kde_full":
             self.kde = self.init_kernel_full(
                 kde_kernel=self.kde_kernel, bandwidth=self.bandwidth
@@ -72,16 +70,14 @@ class KDELikelihood(object):
             )
 
     def kdelikelihood(self):
-        """
-        Evaluates the likelihood. Return a function.
+        """Evaluates the likelihood. Return a function.
 
         __ warning:: you should adjust bandwidth to the spacing of your samples chain!
         """
         return self.kde.score
 
     def kdelikelihood_samples(self, samples):
-        """
-        Evaluates the likelihood on an array. Return an array
+        """Evaluates the likelihood on an array. Return an array.
 
         __ warning:: you should adjust bandwidth to the spacing of your samples chain!
         """
@@ -101,8 +97,9 @@ class KDELikelihood(object):
         return kde
 
     def init_kernel_kdelikelihood_hist_nd(self, kde_kernel, bandwidth, nbins_hist):
-        """
-        Evaluates the likelihood from a Kernel Density Estimator. The KDE is constructed using a binned version of the full samples. Greatly improves speed at the cost of a (tiny) loss in precision
+        """Evaluates the likelihood from a Kernel Density Estimator. The KDE is
+        constructed using a binned version of the full samples. Greatly improves speed
+        at the cost of a (tiny) loss in precision.
 
         __warning:: you should adjust bandwidth and nbins_hist to the spacing and size of your samples chain!
 

--- a/hierarc/Likelihood/LensLikelihood/base_lens_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/base_lens_likelihood.py
@@ -19,9 +19,7 @@ LIKELIHOOD_TYPES = [
 
 
 class LensLikelihoodBase(object):
-    """
-    master class containing the likelihood definitions of different analysis
-    """
+    """Master class containing the likelihood definitions of different analysis."""
 
     def __init__(
         self,
@@ -149,8 +147,7 @@ class LensLikelihoodBase(object):
             )
 
     def num_data(self):
-        """
-        number of data points across the lens sample
+        """Number of data points across the lens sample.
 
         :return: integer
         """
@@ -196,9 +193,8 @@ class LensLikelihoodBase(object):
             )
 
     def ddt_measurement(self):
-        """
-        Inferred Ddt from a lens model (i.e. power-law fit) and time-delay, without lambda correction (excludes also the
-        external convergence contribution)
+        """Inferred Ddt from a lens model (i.e. power-law fit) and time-delay, without
+        lambda correction (excludes also the external convergence contribution)
 
         :return: ddt measurement median, 1-sigma (without lambda correction factor)
         """

--- a/hierarc/Likelihood/LensLikelihood/base_lens_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/base_lens_likelihood.py
@@ -1,16 +1,38 @@
-__author__ = 'sibirrer'
+__author__ = "sibirrer"
 
 
-LIKELIHOOD_TYPES = ['DdtGaussian', 'DdtDdKDE', 'DdtDdGaussian', 'DsDdsGaussian', 'DdtLogNorm', 'IFUKinCov', 'DdtHist',
-                    'DdtHistKDE', 'DdtHistKin', 'DdtGaussKin', 'Mag', 'TDMag', 'TDMagMagnitude']
+LIKELIHOOD_TYPES = [
+    "DdtGaussian",
+    "DdtDdKDE",
+    "DdtDdGaussian",
+    "DsDdsGaussian",
+    "DdtLogNorm",
+    "IFUKinCov",
+    "DdtHist",
+    "DdtHistKDE",
+    "DdtHistKin",
+    "DdtGaussKin",
+    "Mag",
+    "TDMag",
+    "TDMagMagnitude",
+]
 
 
 class LensLikelihoodBase(object):
     """
     master class containing the likelihood definitions of different analysis
     """
-    def __init__(self, z_lens, z_source, likelihood_type, name='name', normalized=False,
-                 kwargs_lens_properties=None, **kwargs_likelihood):
+
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        likelihood_type,
+        name="name",
+        normalized=False,
+        kwargs_lens_properties=None,
+        **kwargs_likelihood
+    ):
         """
 
         :param z_lens: lens redshift
@@ -30,47 +52,101 @@ class LensLikelihoodBase(object):
         if kwargs_lens_properties is None:
             kwargs_lens_properties = {}
         self.kwargs_lens_properties = kwargs_lens_properties
-        if likelihood_type in ['DdtGaussian']:
-            from hierarc.Likelihood.LensLikelihood.ddt_gauss_likelihood import DdtGaussianLikelihood
-            self._lens_type = DdtGaussianLikelihood(z_lens, z_source, **kwargs_likelihood)
-        elif likelihood_type in ['DdtDdKDE']:
-            from hierarc.Likelihood.LensLikelihood.ddt_dd_kde_likelihood import DdtDdKDELikelihood
+        if likelihood_type in ["DdtGaussian"]:
+            from hierarc.Likelihood.LensLikelihood.ddt_gauss_likelihood import (
+                DdtGaussianLikelihood,
+            )
+
+            self._lens_type = DdtGaussianLikelihood(
+                z_lens, z_source, **kwargs_likelihood
+            )
+        elif likelihood_type in ["DdtDdKDE"]:
+            from hierarc.Likelihood.LensLikelihood.ddt_dd_kde_likelihood import (
+                DdtDdKDELikelihood,
+            )
+
             self._lens_type = DdtDdKDELikelihood(z_lens, z_source, **kwargs_likelihood)
-        elif likelihood_type == 'DdtDdGaussian':
-            from hierarc.Likelihood.LensLikelihood.ddt_dd_gauss_likelihood import DdtDdGaussian
+        elif likelihood_type == "DdtDdGaussian":
+            from hierarc.Likelihood.LensLikelihood.ddt_dd_gauss_likelihood import (
+                DdtDdGaussian,
+            )
+
             self._lens_type = DdtDdGaussian(z_lens, z_source, **kwargs_likelihood)
-        elif likelihood_type in ['DsDdsGaussian']:
-            from hierarc.Likelihood.LensLikelihood.ds_dds_gauss_likelihood import DsDdsGaussianLikelihood
-            self._lens_type = DsDdsGaussianLikelihood(z_lens, z_source, **kwargs_likelihood)
-        elif likelihood_type == 'DdtLogNorm':
-            from hierarc.Likelihood.LensLikelihood.ddt_lognorm_likelihood import DdtLogNormLikelihood
-            self._lens_type = DdtLogNormLikelihood(z_lens, z_source, **kwargs_likelihood)
-        elif likelihood_type == 'IFUKinCov':
+        elif likelihood_type in ["DsDdsGaussian"]:
+            from hierarc.Likelihood.LensLikelihood.ds_dds_gauss_likelihood import (
+                DsDdsGaussianLikelihood,
+            )
+
+            self._lens_type = DsDdsGaussianLikelihood(
+                z_lens, z_source, **kwargs_likelihood
+            )
+        elif likelihood_type == "DdtLogNorm":
+            from hierarc.Likelihood.LensLikelihood.ddt_lognorm_likelihood import (
+                DdtLogNormLikelihood,
+            )
+
+            self._lens_type = DdtLogNormLikelihood(
+                z_lens, z_source, **kwargs_likelihood
+            )
+        elif likelihood_type == "IFUKinCov":
             from hierarc.Likelihood.LensLikelihood.kin_likelihood import KinLikelihood
-            self._lens_type = KinLikelihood(z_lens, z_source, normalized=normalized, **kwargs_likelihood)
-        elif likelihood_type == 'DdtHist':
-            from hierarc.Likelihood.LensLikelihood.ddt_hist_likelihood import DdtHistLikelihood
+
+            self._lens_type = KinLikelihood(
+                z_lens, z_source, normalized=normalized, **kwargs_likelihood
+            )
+        elif likelihood_type == "DdtHist":
+            from hierarc.Likelihood.LensLikelihood.ddt_hist_likelihood import (
+                DdtHistLikelihood,
+            )
+
             self._lens_type = DdtHistLikelihood(z_lens, z_source, **kwargs_likelihood)
-        elif likelihood_type == 'DdtHistKDE':
-            from hierarc.Likelihood.LensLikelihood.ddt_hist_likelihood import DdtHistKDELikelihood
-            self._lens_type = DdtHistKDELikelihood(z_lens, z_source, **kwargs_likelihood)
-        elif likelihood_type == 'DdtHistKin':
-            from hierarc.Likelihood.LensLikelihood.ddt_hist_kin_likelihood import DdtHistKinLikelihood
-            self._lens_type = DdtHistKinLikelihood(z_lens, z_source, normalized=normalized, **kwargs_likelihood)
-        elif likelihood_type == 'DdtGaussKin':
-            from hierarc.Likelihood.LensLikelihood.ddt_gauss_kin_likelihood import DdtGaussKinLikelihood
-            self._lens_type = DdtGaussKinLikelihood(z_lens, z_source, normalized=normalized, **kwargs_likelihood)
-        elif likelihood_type == 'Mag':
-            from hierarc.Likelihood.LensLikelihood.mag_likelihood import MagnificationLikelihood
+        elif likelihood_type == "DdtHistKDE":
+            from hierarc.Likelihood.LensLikelihood.ddt_hist_likelihood import (
+                DdtHistKDELikelihood,
+            )
+
+            self._lens_type = DdtHistKDELikelihood(
+                z_lens, z_source, **kwargs_likelihood
+            )
+        elif likelihood_type == "DdtHistKin":
+            from hierarc.Likelihood.LensLikelihood.ddt_hist_kin_likelihood import (
+                DdtHistKinLikelihood,
+            )
+
+            self._lens_type = DdtHistKinLikelihood(
+                z_lens, z_source, normalized=normalized, **kwargs_likelihood
+            )
+        elif likelihood_type == "DdtGaussKin":
+            from hierarc.Likelihood.LensLikelihood.ddt_gauss_kin_likelihood import (
+                DdtGaussKinLikelihood,
+            )
+
+            self._lens_type = DdtGaussKinLikelihood(
+                z_lens, z_source, normalized=normalized, **kwargs_likelihood
+            )
+        elif likelihood_type == "Mag":
+            from hierarc.Likelihood.LensLikelihood.mag_likelihood import (
+                MagnificationLikelihood,
+            )
+
             self._lens_type = MagnificationLikelihood(**kwargs_likelihood)
-        elif likelihood_type == 'TDMag':
-            from hierarc.Likelihood.LensLikelihood.td_mag_likelihood import TDMagLikelihood
+        elif likelihood_type == "TDMag":
+            from hierarc.Likelihood.LensLikelihood.td_mag_likelihood import (
+                TDMagLikelihood,
+            )
+
             self._lens_type = TDMagLikelihood(**kwargs_likelihood)
-        elif likelihood_type == 'TDMagMagnitude':
-            from hierarc.Likelihood.LensLikelihood.td_mag_magnitude_likelihood import TDMagMagnitudeLikelihood
+        elif likelihood_type == "TDMagMagnitude":
+            from hierarc.Likelihood.LensLikelihood.td_mag_magnitude_likelihood import (
+                TDMagMagnitudeLikelihood,
+            )
+
             self._lens_type = TDMagMagnitudeLikelihood(**kwargs_likelihood)
         else:
-            raise ValueError('likelihood_type %s not supported! Supported are %s.' % (likelihood_type, LIKELIHOOD_TYPES))
+            raise ValueError(
+                "likelihood_type %s not supported! Supported are %s."
+                % (likelihood_type, LIKELIHOOD_TYPES)
+            )
 
     def num_data(self):
         """
@@ -80,7 +156,9 @@ class LensLikelihoodBase(object):
         """
         return self._lens_type.num_data
 
-    def log_likelihood(self, ddt, dd, aniso_scaling=None, sigma_v_sys_error=None, mu_intrinsic=None):
+    def log_likelihood(
+        self, ddt, dd, aniso_scaling=None, sigma_v_sys_error=None, mu_intrinsic=None
+    ):
         """
 
         :param ddt: time-delay distance [physical Mpc]
@@ -92,19 +170,30 @@ class LensLikelihoodBase(object):
         :param mu_intrinsic: float, intrinsic source brightness (in magnitude)
         :return: natural logarithm of the likelihood of the data given the model
         """
-        if self.likelihood_type in ['DdtGaussian', 'DdtLogNorm', 'DdtHist', 'DdtHistKDE']:
+        if self.likelihood_type in [
+            "DdtGaussian",
+            "DdtLogNorm",
+            "DdtHist",
+            "DdtHistKDE",
+        ]:
             return self._lens_type.log_likelihood(ddt, dd)
-        elif self.likelihood_type in ['DdtDdKDE', 'DdtDdGaussian', 'DsDdsGaussian']:
+        elif self.likelihood_type in ["DdtDdKDE", "DdtDdGaussian", "DsDdsGaussian"]:
             return self._lens_type.log_likelihood(ddt, dd, aniso_scaling=aniso_scaling)
-        elif self.likelihood_type in ['DdtHistKin', 'IFUKinCov', 'DdtGaussKin']:
-            return self._lens_type.log_likelihood(ddt, dd, aniso_scaling=aniso_scaling,
-                                                  sigma_v_sys_error=sigma_v_sys_error)
-        elif self.likelihood_type in ['Mag']:
+        elif self.likelihood_type in ["DdtHistKin", "IFUKinCov", "DdtGaussKin"]:
+            return self._lens_type.log_likelihood(
+                ddt,
+                dd,
+                aniso_scaling=aniso_scaling,
+                sigma_v_sys_error=sigma_v_sys_error,
+            )
+        elif self.likelihood_type in ["Mag"]:
             return self._lens_type.log_likelihood(mu_intrinsic=mu_intrinsic)
-        elif self.likelihood_type in ['TDMag', 'TDMagMagnitude']:
+        elif self.likelihood_type in ["TDMag", "TDMagMagnitude"]:
             return self._lens_type.log_likelihood(ddt=ddt, mu_intrinsic=mu_intrinsic)
         else:
-            raise ValueError('likelihood type %s not fully supported.' % self.likelihood_type)
+            raise ValueError(
+                "likelihood type %s not fully supported." % self.likelihood_type
+            )
 
     def ddt_measurement(self):
         """
@@ -113,7 +202,13 @@ class LensLikelihoodBase(object):
 
         :return: ddt measurement median, 1-sigma (without lambda correction factor)
         """
-        if self.likelihood_type in ['DdtGaussian', 'DdtHist', 'DdtHistKDE', 'DdtHistKin', 'DdtGaussKin']:
+        if self.likelihood_type in [
+            "DdtGaussian",
+            "DdtHist",
+            "DdtHistKDE",
+            "DdtHistKin",
+            "DdtGaussKin",
+        ]:
             return self._lens_type.ddt_measurement()
         return None, None
 
@@ -123,8 +218,10 @@ class LensLikelihoodBase(object):
 
         :return: data vector, measurement covariance matrix for velocity dispersion
         """
-        if self.likelihood_type in ['DdtHistKin', 'IFUKinCov', 'DdtGaussKin']:
-            return self._lens_type.sigma_v_measurement(sigma_v_sys_error=sigma_v_sys_error)
+        if self.likelihood_type in ["DdtHistKin", "IFUKinCov", "DdtGaussKin"]:
+            return self._lens_type.sigma_v_measurement(
+                sigma_v_sys_error=sigma_v_sys_error
+            )
         return None, None
 
     def sigma_v_prediction(self, ddt, dd, aniso_scaling=None):
@@ -135,6 +232,6 @@ class LensLikelihoodBase(object):
         :param aniso_scaling: anisotropy scaling in J
         :return: model predicted velocity dispersion (vector) and model covariance matrix thereof
         """
-        if self.likelihood_type in ['DdtHistKin', 'IFUKinCov', 'DdtGaussKin']:
+        if self.likelihood_type in ["DdtHistKin", "IFUKinCov", "DdtGaussKin"]:
             return self._lens_type.sigma_v_prediction(ddt, dd, aniso_scaling)
         return None, None

--- a/hierarc/Likelihood/LensLikelihood/ddt_dd_gauss_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_dd_gauss_likelihood.py
@@ -2,8 +2,9 @@ from hierarc.Likelihood.LensLikelihood.ddt_gauss_likelihood import DdtGaussianLi
 
 
 class DdtDdGaussian(object):
-    """
-    class for joint kinematics and time delay likelihood assuming independent Gaussian likelihoods in Ddt and Dd.
+    """Class for joint kinematics and time delay likelihood assuming independent
+    Gaussian likelihoods in Ddt and Dd.
+
     Attention: Gaussian errors in the velocity dispersion do not translate into Gaussian uncertainties in Dd.
     """
 

--- a/hierarc/Likelihood/LensLikelihood/ddt_dd_gauss_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_dd_gauss_likelihood.py
@@ -6,6 +6,7 @@ class DdtDdGaussian(object):
     class for joint kinematics and time delay likelihood assuming independent Gaussian likelihoods in Ddt and Dd.
     Attention: Gaussian errors in the velocity dispersion do not translate into Gaussian uncertainties in Dd.
     """
+
     def __init__(self, z_lens, z_source, ddt_mean, ddt_sigma, dd_mean, dd_sigma):
         """
 
@@ -17,8 +18,10 @@ class DdtDdGaussian(object):
         :param dd_sigma: 1-sigma uncertainty in the Dd distance
         """
         self._dd_mean = dd_mean
-        self._dd_sigma2 = dd_sigma ** 2
-        self._tdLikelihood = DdtGaussianLikelihood(z_lens, z_source, ddt_mean=ddt_mean, ddt_sigma=ddt_sigma)
+        self._dd_sigma2 = dd_sigma**2
+        self._tdLikelihood = DdtGaussianLikelihood(
+            z_lens, z_source, ddt_mean=ddt_mean, ddt_sigma=ddt_sigma
+        )
         self.num_data = 2
 
     def log_likelihood(self, ddt, dd, aniso_scaling=None):
@@ -35,7 +38,10 @@ class DdtDdGaussian(object):
             dd_ = dd * aniso_scaling[0]
         else:
             dd_ = dd
-        lnlikelihood = self._tdLikelihood.log_likelihood(ddt, dd_) - (dd_ - self._dd_mean) ** 2 / self._dd_sigma2 / 2
+        lnlikelihood = (
+            self._tdLikelihood.log_likelihood(ddt, dd_)
+            - (dd_ - self._dd_mean) ** 2 / self._dd_sigma2 / 2
+        )
         return lnlikelihood
 
     def ddt_measurement(self):

--- a/hierarc/Likelihood/LensLikelihood/ddt_dd_kde_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_dd_kde_likelihood.py
@@ -7,8 +7,18 @@ class DdtDdKDELikelihood(object):
     """
     class for evaluating the 2-d posterior of Ddt vs Dd coming from a lens with time delays and kinematics measurement
     """
-    def __init__(self, z_lens, z_source, dd_samples, ddt_samples, kde_type='scipy_gaussian', bandwidth=1,
-                 interpol=False, num_interp_grid=100):
+
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        dd_samples,
+        ddt_samples,
+        kde_type="scipy_gaussian",
+        bandwidth=1,
+        interpol=False,
+        num_interp_grid=100,
+    ):
         """
 
         :param z_lens: lens redshift
@@ -20,16 +30,26 @@ class DdtDdKDELikelihood(object):
         :param interpol: bool, if True pre-computes an interpolation likelihood in 2d on a grid
         :param num_interp_grid: int, number of interpolations per axis
         """
-        self._kde_likelihood = KDELikelihood(dd_samples, ddt_samples, kde_type=kde_type, bandwidth=bandwidth)
+        self._kde_likelihood = KDELikelihood(
+            dd_samples, ddt_samples, kde_type=kde_type, bandwidth=bandwidth
+        )
 
         if interpol is True:
-            dd_grid = np.linspace(start=max(np.min(dd_samples), 0), stop=min(np.max(dd_samples), 10000), num=num_interp_grid)
-            ddt_grid = np.linspace(np.min(ddt_samples), np.max(ddt_samples), num=num_interp_grid)
+            dd_grid = np.linspace(
+                start=max(np.min(dd_samples), 0),
+                stop=min(np.max(dd_samples), 10000),
+                num=num_interp_grid,
+            )
+            ddt_grid = np.linspace(
+                np.min(ddt_samples), np.max(ddt_samples), num=num_interp_grid
+            )
             z = np.zeros((num_interp_grid, num_interp_grid))
             for i, dd in enumerate(dd_grid):
                 for j, ddt in enumerate(ddt_grid):
                     z[j, i] = self._kde_likelihood.logLikelihood(dd, ddt)[0]
-            self._interp_log_likelihood = interpolate.interp2d(dd_grid, ddt_grid, z, kind='cubic')
+            self._interp_log_likelihood = interpolate.interp2d(
+                dd_grid, ddt_grid, z, kind="cubic"
+            )
         self._interpol = interpol
         self.num_data = 2
 

--- a/hierarc/Likelihood/LensLikelihood/ddt_dd_kde_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_dd_kde_likelihood.py
@@ -4,9 +4,8 @@ from scipy import interpolate
 
 
 class DdtDdKDELikelihood(object):
-    """
-    class for evaluating the 2-d posterior of Ddt vs Dd coming from a lens with time delays and kinematics measurement
-    """
+    """Class for evaluating the 2-d posterior of Ddt vs Dd coming from a lens with time
+    delays and kinematics measurement."""
 
     def __init__(
         self,

--- a/hierarc/Likelihood/LensLikelihood/ddt_gauss_kin_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_gauss_kin_likelihood.py
@@ -8,8 +8,20 @@ class DdtGaussKinLikelihood(object):
     class for joint kinematics and time delay likelihood assuming that they are independent
     Uses KinLikelihood and DdtHistLikelihood combined
     """
-    def __init__(self, z_lens, z_source, ddt_mean, ddt_sigma, sigma_v_measurement, j_model, error_cov_measurement,
-                 error_cov_j_sqrt, sigma_sys_error_include=False, normalized=True):
+
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        ddt_mean,
+        ddt_sigma,
+        sigma_v_measurement,
+        j_model,
+        error_cov_measurement,
+        error_cov_j_sqrt,
+        sigma_sys_error_include=False,
+        normalized=True,
+    ):
         """
 
         :param z_lens: lens redshift
@@ -25,13 +37,31 @@ class DdtGaussKinLikelihood(object):
         :param normalized: bool, if True, returns the normalized likelihood, if False, separates the constant prefactor
          (in case of a Gaussian 1/(sigma sqrt(2 pi)) ) to compute the reduced chi2 statistics
         """
-        self._ddt_gauss_likelihood = DdtGaussianLikelihood(z_lens, z_source, ddt_mean=ddt_mean, ddt_sigma=ddt_sigma)
-        self._kinlikelihood = KinLikelihood(z_lens, z_source, sigma_v_measurement, j_model, error_cov_measurement,
-                                            error_cov_j_sqrt, sigma_sys_error_include=sigma_sys_error_include,
-                                            normalized=normalized)
-        self.num_data = self._ddt_gauss_likelihood.num_data + self._kinlikelihood.num_data
+        self._ddt_gauss_likelihood = DdtGaussianLikelihood(
+            z_lens, z_source, ddt_mean=ddt_mean, ddt_sigma=ddt_sigma
+        )
+        self._kinlikelihood = KinLikelihood(
+            z_lens,
+            z_source,
+            sigma_v_measurement,
+            j_model,
+            error_cov_measurement,
+            error_cov_j_sqrt,
+            sigma_sys_error_include=sigma_sys_error_include,
+            normalized=normalized,
+        )
+        self.num_data = (
+            self._ddt_gauss_likelihood.num_data + self._kinlikelihood.num_data
+        )
 
-    def log_likelihood(self, ddt, dd, aniso_scaling=None, sigma_v_sys_error=None, sigma_v_sys_offset=None):
+    def log_likelihood(
+        self,
+        ddt,
+        dd,
+        aniso_scaling=None,
+        sigma_v_sys_error=None,
+        sigma_v_sys_offset=None,
+    ):
         """
 
         :param ddt: time-delay distance
@@ -44,9 +74,15 @@ class DdtGaussKinLikelihood(object):
          such that sigma_v = sigma_v_measured * (1 + sigma_v_sys_offset)
         :return: log likelihood given the single lens analysis
         """
-        lnlikelihood = self._ddt_gauss_likelihood.log_likelihood(ddt) + self._kinlikelihood.log_likelihood(ddt, dd, aniso_scaling,
-                                                                                                           sigma_v_sys_error=sigma_v_sys_error,
-                                                                                                           sigma_v_sys_offset=sigma_v_sys_offset)
+        lnlikelihood = self._ddt_gauss_likelihood.log_likelihood(
+            ddt
+        ) + self._kinlikelihood.log_likelihood(
+            ddt,
+            dd,
+            aniso_scaling,
+            sigma_v_sys_error=sigma_v_sys_error,
+            sigma_v_sys_offset=sigma_v_sys_offset,
+        )
         return lnlikelihood
 
     def sigma_v_prediction(self, ddt, dd, aniso_scaling=1):
@@ -70,8 +106,9 @@ class DdtGaussKinLikelihood(object):
          such that sigma_v = sigma_v_measured * (1 + sigma_v_sys_offset)
         :return: measurement mean (vector), measurement covariance matrix
         """
-        return self._kinlikelihood.sigma_v_measurement(sigma_v_sys_error=sigma_v_sys_error,
-                                                       sigma_v_sys_offset=sigma_v_sys_offset)
+        return self._kinlikelihood.sigma_v_measurement(
+            sigma_v_sys_error=sigma_v_sys_error, sigma_v_sys_offset=sigma_v_sys_offset
+        )
 
     def ddt_measurement(self):
         """

--- a/hierarc/Likelihood/LensLikelihood/ddt_gauss_kin_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_gauss_kin_likelihood.py
@@ -3,11 +3,8 @@ from hierarc.Likelihood.LensLikelihood.ddt_gauss_likelihood import DdtGaussianLi
 
 
 class DdtGaussKinLikelihood(object):
-
-    """
-    class for joint kinematics and time delay likelihood assuming that they are independent
-    Uses KinLikelihood and DdtHistLikelihood combined
-    """
+    """Class for joint kinematics and time delay likelihood assuming that they are
+    independent Uses KinLikelihood and DdtHistLikelihood combined."""
 
     def __init__(
         self,
@@ -86,15 +83,18 @@ class DdtGaussKinLikelihood(object):
         return lnlikelihood
 
     def sigma_v_prediction(self, ddt, dd, aniso_scaling=1):
-        """
-        model prediction mean velocity dispersion vector and model prediction covariance matrix
+        """Model prediction mean velocity dispersion vector and model prediction
+        covariance matrix.
 
         :param ddt: time-delay distance
         :param dd: angular diameter distance to the deflector
-        :param aniso_scaling: array of size of the velocity dispersion measurement or None, scaling of the predicted
-         dimensionless quantity J (proportional to sigma_v^2) of the anisotropy model in the sampling relative to the
-         anisotropy model used to derive the prediction and covariance matrix in the init of this class.
-        :return: model prediction mean velocity dispersion vector and model prediction covariance matrix
+        :param aniso_scaling: array of size of the velocity dispersion measurement or
+            None, scaling of the predicted dimensionless quantity J (proportional to
+            sigma_v^2) of the anisotropy model in the sampling relative to the
+            anisotropy model used to derive the prediction and covariance matrix in the
+            init of this class.
+        :return: model prediction mean velocity dispersion vector and model prediction
+            covariance matrix
         """
         return self._kinlikelihood.sigma_v_prediction(ddt, dd, aniso_scaling)
 

--- a/hierarc/Likelihood/LensLikelihood/ddt_gauss_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_gauss_likelihood.py
@@ -1,4 +1,3 @@
-
 class DdtGaussianLikelihood(object):
     """
     class to handle cosmographic likelihood coming from modeling lenses with imaging and kinematic data but no time delays.
@@ -6,6 +5,7 @@ class DdtGaussianLikelihood(object):
 
     The current version includes a Gaussian in Ds/Dds but can be extended.
     """
+
     def __init__(self, z_lens, z_source, ddt_mean, ddt_sigma):
         """
 
@@ -17,7 +17,7 @@ class DdtGaussianLikelihood(object):
         self._z_lens = z_lens
         self._ddt_mean = ddt_mean
         self._ddt_sigma = ddt_sigma
-        self._ddt_sigma2 = ddt_sigma ** 2
+        self._ddt_sigma2 = ddt_sigma**2
         self.num_data = 1
 
     def log_likelihood(self, ddt, dd=None):
@@ -27,7 +27,7 @@ class DdtGaussianLikelihood(object):
         :param dd: angular diameter distance to the deflector
         :return: log likelihood given the single lens analysis
         """
-        return - (ddt - self._ddt_mean) ** 2 / self._ddt_sigma2 / 2
+        return -((ddt - self._ddt_mean) ** 2) / self._ddt_sigma2 / 2
 
     def ddt_measurement(self):
         """

--- a/hierarc/Likelihood/LensLikelihood/ddt_gauss_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_gauss_likelihood.py
@@ -1,7 +1,7 @@
 class DdtGaussianLikelihood(object):
-    """
-    class to handle cosmographic likelihood coming from modeling lenses with imaging and kinematic data but no time delays.
-    Thus Ddt is not constrained but the kinematics can constrain Ds/Dds
+    """Class to handle cosmographic likelihood coming from modeling lenses with imaging
+    and kinematic data but no time delays. Thus Ddt is not constrained but the
+    kinematics can constrain Ds/Dds.
 
     The current version includes a Gaussian in Ds/Dds but can be extended.
     """

--- a/hierarc/Likelihood/LensLikelihood/ddt_hist_kin_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_hist_kin_likelihood.py
@@ -3,11 +3,8 @@ from hierarc.Likelihood.LensLikelihood.ddt_hist_likelihood import DdtHistKDELike
 
 
 class DdtHistKinLikelihood(object):
-
-    """
-    class for joint kinematics and time delay likelihood assuming that they are independent
-    Uses KinLikelihood and DdtHistLikelihood combined
-    """
+    """Class for joint kinematics and time delay likelihood assuming that they are
+    independent Uses KinLikelihood and DdtHistLikelihood combined."""
 
     def __init__(
         self,
@@ -80,15 +77,18 @@ class DdtHistKinLikelihood(object):
         return lnlikelihood
 
     def sigma_v_prediction(self, ddt, dd, aniso_scaling=1):
-        """
-        model prediction mean velocity dispersion vector and model prediction covariance matrix
+        """Model prediction mean velocity dispersion vector and model prediction
+        covariance matrix.
 
         :param ddt: time-delay distance
         :param dd: angular diameter distance to the deflector
-        :param aniso_scaling: array of size of the velocity dispersion measurement or None, scaling of the predicted
-         dimensionless quantity J (proportional to sigma_v^2) of the anisotropy model in the sampling relative to the
-         anisotropy model used to derive the prediction and covariance matrix in the init of this class.
-        :return: model prediction mean velocity dispersion vector and model prediction covariance matrix
+        :param aniso_scaling: array of size of the velocity dispersion measurement or
+            None, scaling of the predicted dimensionless quantity J (proportional to
+            sigma_v^2) of the anisotropy model in the sampling relative to the
+            anisotropy model used to derive the prediction and covariance matrix in the
+            init of this class.
+        :return: model prediction mean velocity dispersion vector and model prediction
+            covariance matrix
         """
         return self._kinlikelihood.sigma_v_prediction(ddt, dd, aniso_scaling)
 

--- a/hierarc/Likelihood/LensLikelihood/ddt_hist_kin_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_hist_kin_likelihood.py
@@ -8,9 +8,23 @@ class DdtHistKinLikelihood(object):
     class for joint kinematics and time delay likelihood assuming that they are independent
     Uses KinLikelihood and DdtHistLikelihood combined
     """
-    def __init__(self, z_lens, z_source, ddt_samples, sigma_v_measurement, j_model, error_cov_measurement,
-                 error_cov_j_sqrt, ddt_weights=None, kde_kernel='gaussian', bandwidth=20, nbins_hist=200,
-                 sigma_sys_error_include=False, normalized=True):
+
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        ddt_samples,
+        sigma_v_measurement,
+        j_model,
+        error_cov_measurement,
+        error_cov_j_sqrt,
+        ddt_weights=None,
+        kde_kernel="gaussian",
+        bandwidth=20,
+        nbins_hist=200,
+        sigma_sys_error_include=False,
+        normalized=True,
+    ):
         """
 
         :param z_lens: lens redshift
@@ -29,11 +43,25 @@ class DdtHistKinLikelihood(object):
         :param normalized: bool, if True, returns the normalized likelihood, if False, separates the constant prefactor
          (in case of a Gaussian 1/(sigma sqrt(2 pi)) ) to compute the reduced chi2 statistics
         """
-        self._tdLikelihood = DdtHistKDELikelihood(z_lens, z_source, ddt_samples, ddt_weights=ddt_weights,
-                                                  kde_kernel=kde_kernel, bandwidth=bandwidth, nbins_hist=nbins_hist)
-        self._kinlikelihood = KinLikelihood(z_lens, z_source, sigma_v_measurement, j_model, error_cov_measurement,
-                                            error_cov_j_sqrt, sigma_sys_error_include=sigma_sys_error_include,
-                                            normalized=normalized)
+        self._tdLikelihood = DdtHistKDELikelihood(
+            z_lens,
+            z_source,
+            ddt_samples,
+            ddt_weights=ddt_weights,
+            kde_kernel=kde_kernel,
+            bandwidth=bandwidth,
+            nbins_hist=nbins_hist,
+        )
+        self._kinlikelihood = KinLikelihood(
+            z_lens,
+            z_source,
+            sigma_v_measurement,
+            j_model,
+            error_cov_measurement,
+            error_cov_j_sqrt,
+            sigma_sys_error_include=sigma_sys_error_include,
+            normalized=normalized,
+        )
         self.num_data = self._tdLikelihood.num_data + self._kinlikelihood.num_data
 
     def log_likelihood(self, ddt, dd, aniso_scaling=None, sigma_v_sys_error=None):
@@ -44,7 +72,11 @@ class DdtHistKinLikelihood(object):
         :param aniso_scaling: numpy array of anisotropy scaling on prediction of Ds/Dds
         :return: log likelihood given the single lens analysis
         """
-        lnlikelihood = self._tdLikelihood.log_likelihood(ddt) + self._kinlikelihood.log_likelihood(ddt, dd, aniso_scaling, sigma_v_sys_error=sigma_v_sys_error)
+        lnlikelihood = self._tdLikelihood.log_likelihood(
+            ddt
+        ) + self._kinlikelihood.log_likelihood(
+            ddt, dd, aniso_scaling, sigma_v_sys_error=sigma_v_sys_error
+        )
         return lnlikelihood
 
     def sigma_v_prediction(self, ddt, dd, aniso_scaling=1):
@@ -68,8 +100,9 @@ class DdtHistKinLikelihood(object):
          such that sigma_v = sigma_v_measured * (1 + sigma_v_sys_offset)
         :return: measurement mean (vector), measurement covariance matrix
         """
-        return self._kinlikelihood.sigma_v_measurement(sigma_v_sys_error=sigma_v_sys_error,
-                                                       sigma_v_sys_offset=sigma_v_sys_offset)
+        return self._kinlikelihood.sigma_v_measurement(
+            sigma_v_sys_error=sigma_v_sys_error, sigma_v_sys_offset=sigma_v_sys_offset
+        )
 
     def ddt_measurement(self):
         """

--- a/hierarc/Likelihood/LensLikelihood/ddt_hist_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_hist_likelihood.py
@@ -5,11 +5,10 @@ from sklearn.neighbors import KernelDensity
 
 
 class DdtHistLikelihood(object):
-    """
-    Evaluates the likelihood of a time-delay distance ddt (in Mpc) against the
-    model predictions, using a loglikelihood sampled from a Kernel Density
-    Estimator. The KDE is constructed using a binned version of the full samples.
-    Greatly improves speed at the cost of a (tiny) loss in precision.
+    """Evaluates the likelihood of a time-delay distance ddt (in Mpc) against the model
+    predictions, using a loglikelihood sampled from a Kernel Density Estimator. The KDE
+    is constructed using a binned version of the full samples. Greatly improves speed at
+    the cost of a (tiny) loss in precision.
 
     .. warning::
 
@@ -19,7 +18,6 @@ class DdtHistLikelihood(object):
     original source:
     https://github.com/shsuyu/H0LiCOW-public/blob/master/H0_inference_code/lensutils.py
     credits to Martin Millon, Aymeric Galan
-
     """
 
     def __init__(
@@ -90,10 +88,10 @@ class DdtHistLikelihood(object):
 
 
 class DdtHistKDELikelihood(object):
-    """
-    Evaluates the likelihood of a time-delay distance ddt (in Mpc) against the model predictions, using a
-         loglikelihood sampled from a Kernel Density Estimator. the KDE is constructed using a binned version of the
-         full samples. Greatly improves speed at the cost of a (tiny) loss in precision
+    """Evaluates the likelihood of a time-delay distance ddt (in Mpc) against the model
+    predictions, using a loglikelihood sampled from a Kernel Density Estimator. the KDE
+    is constructed using a binned version of the full samples. Greatly improves speed at
+    the cost of a (tiny) loss in precision.
 
     __warning:: you should adjust bandwidth and nbins_hist to the spacing and size of your samples chain!
 

--- a/hierarc/Likelihood/LensLikelihood/ddt_hist_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_hist_likelihood.py
@@ -21,9 +21,17 @@ class DdtHistLikelihood(object):
     credits to Martin Millon, Aymeric Galan
 
     """
-    def __init__(self, z_lens, z_source,
-                 ddt_samples, ddt_weights=None,
-                 nbins_hist=200, normalized=False, binning_method=None):
+
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        ddt_samples,
+        ddt_weights=None,
+        nbins_hist=200,
+        normalized=False,
+        binning_method=None,
+    ):
         """
 
         :param z_lens: lens redshift
@@ -40,28 +48,24 @@ class DdtHistLikelihood(object):
 
         """
         if binning_method is None:
-            hist = np.histogram(ddt_samples,
-                                bins=nbins_hist,
-                                weights=ddt_weights)
+            hist = np.histogram(ddt_samples, bins=nbins_hist, weights=ddt_weights)
             vals = hist[0]
-            bins = [(h + hist[1][i+1])/2.0 for i, h in enumerate(hist[1][:-1])]
+            bins = [(h + hist[1][i + 1]) / 2.0 for i, h in enumerate(hist[1][:-1])]
             # ignore potential zero weights, sklearn does not like them
             kde_bins = [b for v, b in zip(vals, bins) if v > 0]
             kde_weights = [v for v in vals if v > 0]
-            self._kde = gaussian_kde(dataset=kde_bins,
-                                     weights=kde_weights[:])
+            self._kde = gaussian_kde(dataset=kde_bins, weights=kde_weights[:])
         else:
-            self._kde = gaussian_kde(dataset=ddt_samples,
-                                     bw_method=binning_method,
-                                     weights=ddt_weights)
+            self._kde = gaussian_kde(
+                dataset=ddt_samples, bw_method=binning_method, weights=ddt_weights
+            )
         self.num_data = 1
         self._sigma = np.std(ddt_samples)
         self._norm_factor = 0
         if normalized is False:
-            self._norm_factor = np.log(1. / self._sigma / np.sqrt(2*np.pi))
+            self._norm_factor = np.log(1.0 / self._sigma / np.sqrt(2 * np.pi))
         self._ddt_mean = np.average(ddt_samples, weights=ddt_weights)
-        variance = np.average((ddt_samples - self._ddt_mean) ** 2,
-                              weights=ddt_weights)
+        variance = np.average((ddt_samples - self._ddt_mean) ** 2, weights=ddt_weights)
         self._ddt_sigma = math.sqrt(variance)
 
     def log_likelihood(self, ddt, dd=None):
@@ -96,8 +100,18 @@ class DdtHistKDELikelihood(object):
     original source: https://github.com/shsuyu/H0LiCOW-public/blob/master/H0_inference_code/lensutils.py
     credits to Martin Millon, Aymeric Galan
     """
-    def __init__(self, z_lens, z_source, ddt_samples, kde_kernel='gaussian', ddt_weights=None, bandwidth=20, nbins_hist=200,
-                 normalized=False):
+
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        ddt_samples,
+        kde_kernel="gaussian",
+        ddt_weights=None,
+        bandwidth=20,
+        nbins_hist=200,
+        normalized=False,
+    ):
         """
 
         :param z_lens: lens redshift
@@ -111,20 +125,24 @@ class DdtHistKDELikelihood(object):
          (in case of a Gaussian 1/(sigma sqrt(2 pi)) ) to compute the reduced chi2 statistics
         """
 
-        vals, bin_edges = np.histogram(ddt_samples, bins=nbins_hist, weights=ddt_weights, density=True)
+        vals, bin_edges = np.histogram(
+            ddt_samples, bins=nbins_hist, weights=ddt_weights, density=True
+        )
         bins = [(h + bin_edges[i + 1]) / 2.0 for i, h in enumerate(bin_edges[:-1])]
 
         # ignore potential zero weights, sklearn does not like them
         kde_bins = [(b,) for v, b in zip(vals, bins) if v > 0]
         kde_weights = [v for v in vals if v > 0]
 
-        kde = KernelDensity(kernel=kde_kernel, bandwidth=bandwidth).fit(kde_bins, sample_weight=kde_weights)
+        kde = KernelDensity(kernel=kde_kernel, bandwidth=bandwidth).fit(
+            kde_bins, sample_weight=kde_weights
+        )
         self._score = kde.score
         self.num_data = 1
         self._sigma = np.std(ddt_samples)
         self._norm_factor = 0
         if normalized is False:
-            self._norm_factor = np.log(1. / self._sigma / np.sqrt(2*np.pi))
+            self._norm_factor = np.log(1.0 / self._sigma / np.sqrt(2 * np.pi))
         self._ddt_mean = np.average(ddt_samples, weights=ddt_weights)
         variance = np.average((ddt_samples - self._ddt_mean) ** 2, weights=ddt_weights)
         self._ddt_sigma = math.sqrt(variance)

--- a/hierarc/Likelihood/LensLikelihood/ddt_lognorm_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_lognorm_likelihood.py
@@ -8,6 +8,7 @@ class DdtLogNormLikelihood(object):
 
     The current version includes a Gaussian in Ds/Dds but can be extended.
     """
+
     def __init__(self, z_lens, z_source, ddt_mu, ddt_sigma):
         """
         :param z_lens: lens redshift
@@ -17,7 +18,7 @@ class DdtLogNormLikelihood(object):
         """
         self._z_lens = z_lens
         self._ddt_mu = ddt_mu
-        self._ddt_sigma2 = ddt_sigma ** 2
+        self._ddt_sigma2 = ddt_sigma**2
         self.num_data = 1
 
     def log_likelihood(self, ddt, dd=None):
@@ -28,4 +29,8 @@ class DdtLogNormLikelihood(object):
         :param dd: angular diameter distance to the deflector
         :return: log likelihood given the single lens analysis
         """
-        return -0.5*(np.log(ddt) - self._ddt_mu)**2/self._ddt_sigma2 - np.log(ddt) - 0.5*np.log(self._ddt_sigma2)
+        return (
+            -0.5 * (np.log(ddt) - self._ddt_mu) ** 2 / self._ddt_sigma2
+            - np.log(ddt)
+            - 0.5 * np.log(self._ddt_sigma2)
+        )

--- a/hierarc/Likelihood/LensLikelihood/ddt_lognorm_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ddt_lognorm_likelihood.py
@@ -2,9 +2,9 @@ import numpy as np
 
 
 class DdtLogNormLikelihood(object):
-    """
-    The cosmographic likelihood coming from modeling lenses with imaging and kinematic data but no time delays, where the form of the likelihood is a lognormal distribution.
-    Thus Ddt is not constrained but the kinematics can constrain Ds/Dds
+    """The cosmographic likelihood coming from modeling lenses with imaging and
+    kinematic data but no time delays, where the form of the likelihood is a lognormal
+    distribution. Thus Ddt is not constrained but the kinematics can constrain Ds/Dds.
 
     The current version includes a Gaussian in Ds/Dds but can be extended.
     """

--- a/hierarc/Likelihood/LensLikelihood/double_source_plane.py
+++ b/hierarc/Likelihood/LensLikelihood/double_source_plane.py
@@ -7,7 +7,15 @@ class DSPLikelihood(object):
 
     """
 
-    def __init__(self, z_lens, z_source_1, z_source_2, beta_dspl, sigma_beta_dspl, normalized=False):
+    def __init__(
+        self,
+        z_lens,
+        z_source_1,
+        z_source_2,
+        beta_dspl,
+        sigma_beta_dspl,
+        normalized=False,
+    ):
         """
         :param z_lens: lens redshift
         :param z_source_1: redshift of first source
@@ -24,7 +32,9 @@ class DSPLikelihood(object):
         self._sigma_beta_dspl = sigma_beta_dspl
         self._normalized = normalized
 
-    def lens_log_likelihood(self, cosmo, kwargs_lens=None, kwargs_kin=None, kwargs_source=None):
+    def lens_log_likelihood(
+        self, cosmo, kwargs_lens=None, kwargs_kin=None, kwargs_source=None
+    ):
         """
         log likelihood of the data given a model
 
@@ -35,9 +45,9 @@ class DSPLikelihood(object):
         :return: log likelihood of data given model
         """
         beta_model = self._beta_model(cosmo)
-        log_l = - 0.5 * ((beta_model - self._beta_dspl) / self._sigma_beta_dspl)**2
+        log_l = -0.5 * ((beta_model - self._beta_dspl) / self._sigma_beta_dspl) ** 2
         if self._normalized:
-            log_l -= 1 / 2. * np.log(2 * np.pi * self._sigma_beta_dspl**2)
+            log_l -= 1 / 2.0 * np.log(2 * np.pi * self._sigma_beta_dspl**2)
         return log_l
 
     def num_data(self):
@@ -54,7 +64,9 @@ class DSPLikelihood(object):
         :param cosmo: astropy.cosmology instance
         :return: beta
         """
-        beta = beta_double_source_plane(self._z_lens, self._z_source_1, self._z_source_2, cosmo=cosmo)
+        beta = beta_double_source_plane(
+            self._z_lens, self._z_source_1, self._z_source_2, cosmo=cosmo
+        )
         return beta
 
 

--- a/hierarc/Likelihood/LensLikelihood/double_source_plane.py
+++ b/hierarc/Likelihood/LensLikelihood/double_source_plane.py
@@ -2,10 +2,7 @@ import numpy as np
 
 
 class DSPLikelihood(object):
-    """
-    likelihood for Einstein ratios in double source plane lenses
-
-    """
+    """Likelihood for Einstein ratios in double source plane lenses."""
 
     def __init__(
         self,
@@ -35,8 +32,7 @@ class DSPLikelihood(object):
     def lens_log_likelihood(
         self, cosmo, kwargs_lens=None, kwargs_kin=None, kwargs_source=None
     ):
-        """
-        log likelihood of the data given a model
+        """Log likelihood of the data given a model.
 
         :param cosmo: astropy.cosmology instance
         :param kwargs_lens: keyword arguments of lens
@@ -58,8 +54,8 @@ class DSPLikelihood(object):
         return 1
 
     def _beta_model(self, cosmo):
-        """
-        model prediction of ratio of Einstein radii theta_E_1 / theta_E_2 or scaled deflection angles
+        """Model prediction of ratio of Einstein radii theta_E_1 / theta_E_2 or scaled
+        deflection angles.
 
         :param cosmo: astropy.cosmology instance
         :return: beta
@@ -71,8 +67,8 @@ class DSPLikelihood(object):
 
 
 def beta_double_source_plane(z_lens, z_source_1, z_source_2, cosmo):
-    """
-    model prediction of ratio of Einstein radii theta_E_1 / theta_E_2 or scaled deflection angles
+    """Model prediction of ratio of Einstein radii theta_E_1 / theta_E_2 or scaled
+    deflection angles.
 
     :param z_lens: lens redshift
     :param z_source_1: source_1 redshift

--- a/hierarc/Likelihood/LensLikelihood/ds_dds_gauss_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ds_dds_gauss_likelihood.py
@@ -1,10 +1,10 @@
-
 class DsDdsGaussianLikelihood(object):
     """
     class to handle cosmographic likelihood coming from modeling lenses with imaging and kinematic data but no time delays.
     Thus Ddt is not constrained but the kinematics can constrain Ds/Dds. The likelihood in Ds/Dds is assumed Gaussian.
     Attention: Gaussian uncertainties in velocity dispersion do not translate into Gaussian uncertainties in Ds/Dds.
     """
+
     def __init__(self, z_lens, z_source, ds_dds_mean, ds_dds_sigma):
         """
 
@@ -15,7 +15,7 @@ class DsDdsGaussianLikelihood(object):
         """
         self._z_lens = z_lens
         self._ds_dds_mean = ds_dds_mean
-        self._ds_dds_sigma2 = ds_dds_sigma ** 2
+        self._ds_dds_sigma2 = ds_dds_sigma**2
         self.num_data = 1
 
     def log_likelihood(self, ddt, dd, aniso_scaling=None):
@@ -35,4 +35,4 @@ class DsDdsGaussianLikelihood(object):
         else:
             scaling = 1
         ds_dds_ = ds_dds / scaling
-        return - (ds_dds_ - self._ds_dds_mean) ** 2 / self._ds_dds_sigma2 / 2
+        return -((ds_dds_ - self._ds_dds_mean) ** 2) / self._ds_dds_sigma2 / 2

--- a/hierarc/Likelihood/LensLikelihood/ds_dds_gauss_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/ds_dds_gauss_likelihood.py
@@ -1,6 +1,7 @@
 class DsDdsGaussianLikelihood(object):
-    """
-    class to handle cosmographic likelihood coming from modeling lenses with imaging and kinematic data but no time delays.
+    """Class to handle cosmographic likelihood coming from modeling lenses with imaging
+    and kinematic data but no time delays.
+
     Thus Ddt is not constrained but the kinematics can constrain Ds/Dds. The likelihood in Ds/Dds is assumed Gaussian.
     Attention: Gaussian uncertainties in velocity dispersion do not translate into Gaussian uncertainties in Ds/Dds.
     """

--- a/hierarc/Likelihood/LensLikelihood/kin_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/kin_likelihood.py
@@ -5,9 +5,8 @@ import numpy as np
 
 
 class KinLikelihood(object):
-    """
-    likelihood to deal with IFU kinematics constraints with covariances in both the model and measured velocity dispersion
-    """
+    """Likelihood to deal with IFU kinematics constraints with covariances in both the
+    model and measured velocity dispersion."""
 
     def __init__(
         self,
@@ -100,8 +99,7 @@ class KinLikelihood(object):
             return self._sigma_v_measured * (1 + sigma_v_sys_offset)
 
     def sigma_v_model(self, ds_dds, aniso_scaling=1):
-        """
-        model predicted velocity dispersion for the IFU's
+        """Model predicted velocity dispersion for the IFU's.
 
         :param ds_dds: Ds/Dds
         :param aniso_scaling: scaling of the anisotropy affecting sigma_v^2
@@ -137,15 +135,18 @@ class KinLikelihood(object):
             return self._error_cov_measurement
 
     def sigma_v_prediction(self, ddt, dd, aniso_scaling=1):
-        """
-        model prediction mean velocity dispersion vector and model prediction covariance matrix
+        """Model prediction mean velocity dispersion vector and model prediction
+        covariance matrix.
 
         :param ddt: time-delay distance
         :param dd: angular diameter distance to the deflector
-        :param aniso_scaling: array of size of the velocity dispersion measurement or None, scaling of the predicted
-         dimensionless quantity J (proportional to sigma_v^2) of the anisotropy model in the sampling relative to the
-         anisotropy model used to derive the prediction and covariance matrix in the init of this class.
-        :return: model prediction mean velocity dispersion vector and model prediction covariance matrix
+        :param aniso_scaling: array of size of the velocity dispersion measurement or
+            None, scaling of the predicted dimensionless quantity J (proportional to
+            sigma_v^2) of the anisotropy model in the sampling relative to the
+            anisotropy model used to derive the prediction and covariance matrix in the
+            init of this class.
+        :return: model prediction mean velocity dispersion vector and model prediction
+            covariance matrix
         """
         ds_dds = np.maximum(ddt / dd / (1 + self._z_lens), 0)
         sigma_v_predict = self.sigma_v_model(ds_dds, aniso_scaling)

--- a/hierarc/Likelihood/LensLikelihood/mag_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/mag_likelihood.py
@@ -8,8 +8,15 @@ class MagnificationLikelihood(object):
     This can i.e. be applied to lensed SNIa on the population level
 
     """
-    def __init__(self, amp_measured, cov_amp_measured, magnification_model, cov_magnification_model,
-                 magnitude_zero_point=20):
+
+    def __init__(
+        self,
+        amp_measured,
+        cov_amp_measured,
+        magnification_model,
+        cov_magnification_model,
+        magnitude_zero_point=20,
+    ):
         """
 
         :param amp_measured: array, amplitudes of measured fluxes of image positions
@@ -46,9 +53,9 @@ class MagnificationLikelihood(object):
         # difference to data vector
         delta = self._amp_measured - model_vector
         # evaluate likelihood
-        lnlikelihood = -delta.dot(cov_tot_inv.dot(delta)) / 2.
+        lnlikelihood = -delta.dot(cov_tot_inv.dot(delta)) / 2.0
         sign_det, lndet = np.linalg.slogdet(cov_tot)
-        lnlikelihood -= 1 / 2. * (self.num_data * np.log(2 * np.pi) + lndet)
+        lnlikelihood -= 1 / 2.0 * (self.num_data * np.log(2 * np.pi) + lndet)
         return lnlikelihood
 
     def _scale_model(self, mu_intrinsic):
@@ -57,12 +64,13 @@ class MagnificationLikelihood(object):
         :param mu_intrinsic: intrinsic brightness of the source (already incorporating the inverse MST transform)
         :return:
         """
-        amp_intrinsic = magnitude2cps(magnitude=mu_intrinsic, magnitude_zero_point=self._magnitude_zero_point)
+        amp_intrinsic = magnitude2cps(
+            magnitude=mu_intrinsic, magnitude_zero_point=self._magnitude_zero_point
+        )
         # compute model predicted magnified image amplitude and time delay
         model_vector = amp_intrinsic * self._mean_magnification_model
         # scale model covariance matrix with model_scale vector (in quadrature)
-        cov_model = self._cov_magnification_model * amp_intrinsic ** 2
+        cov_model = self._cov_magnification_model * amp_intrinsic**2
         # combine data and model covariance matrix
         cov_tot = self._cov_amp_measured + cov_model
         return model_vector, cov_tot
-

--- a/hierarc/Likelihood/LensLikelihood/mag_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/mag_likelihood.py
@@ -3,11 +3,9 @@ from lenstronomy.Util.data_util import magnitude2cps
 
 
 class MagnificationLikelihood(object):
-    """
-    likelihood of an unlensed apprarent source magnification given a measurement of the magnified brightness
-    This can i.e. be applied to lensed SNIa on the population level
-
-    """
+    """Likelihood of an unlensed apprarent source magnification given a measurement of
+    the magnified brightness This can i.e. be applied to lensed SNIa on the population
+    level."""
 
     def __init__(
         self,

--- a/hierarc/Likelihood/LensLikelihood/td_mag_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/td_mag_likelihood.py
@@ -4,11 +4,9 @@ from lenstronomy.Util.data_util import magnitude2cps
 
 
 class TDMagLikelihood(object):
-    """
-    likelihood of time delays and magnification likelihood
+    """Likelihood of time delays and magnification likelihood.
 
     This likelihood uses linear flux units and linear lensing magnifications.
-
     """
 
     def __init__(
@@ -82,12 +80,12 @@ class TDMagLikelihood(object):
         return lnlikelihood
 
     def _model_cov(self, ddt, mu_intrinsic):
-        """
-        combined covariance matrix of the data and model when marginialized over the Gaussian model uncertainties
-        in the Fermat potential and magnification.
+        """Combined covariance matrix of the data and model when marginialized over the
+        Gaussian model uncertainties in the Fermat potential and magnification.
 
         :param ddt: time-delay distance (physical Mpc)
-        :param mu_intrinsic: intrinsic brightness of the source (already incorporating the inverse MST transform)
+        :param mu_intrinsic: intrinsic brightness of the source (already incorporating
+            the inverse MST transform)
         :return: model vector, combined covariance matrix
         """
         # compute model predicted magnified image amplitude and time delay

--- a/hierarc/Likelihood/LensLikelihood/td_mag_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/td_mag_likelihood.py
@@ -10,8 +10,18 @@ class TDMagLikelihood(object):
     This likelihood uses linear flux units and linear lensing magnifications.
 
     """
-    def __init__(self, time_delay_measured, cov_td_measured, amp_measured, cov_amp_measured,
-                 fermat_diff, magnification_model, cov_model, magnitude_zero_point=20):
+
+    def __init__(
+        self,
+        time_delay_measured,
+        cov_td_measured,
+        amp_measured,
+        cov_amp_measured,
+        fermat_diff,
+        magnification_model,
+        cov_model,
+        magnitude_zero_point=20,
+    ):
         """
 
         :param time_delay_measured: array, relative time delays (relative to the first image) [days]
@@ -38,11 +48,13 @@ class TDMagLikelihood(object):
         assert n_tot == len(cov_model)
         # merge data covariance matrices from time delay and image amplitudes
         self._cov_data = np.zeros((n_tot, n_tot))
-        self._cov_data[:self._n_td, :self._n_td] = self._cov_td_measured
-        self._cov_data[self._n_td:, self._n_td:] = self._cov_amp_measured
-        #self._fermat_diff = fermat_diff   # in units arcsec^2
-        self._fermat_unit_conversion = const.Mpc / const.c / const.day_s * const.arcsec ** 2
-        #self._mag_model = mag_model
+        self._cov_data[: self._n_td, : self._n_td] = self._cov_td_measured
+        self._cov_data[self._n_td :, self._n_td :] = self._cov_amp_measured
+        # self._fermat_diff = fermat_diff   # in units arcsec^2
+        self._fermat_unit_conversion = (
+            const.Mpc / const.c / const.day_s * const.arcsec**2
+        )
+        # self._mag_model = mag_model
         self._model_tot = np.append(fermat_diff, magnification_model)
         self._cov_model = cov_model
         self.num_data = n_tot
@@ -64,9 +76,9 @@ class TDMagLikelihood(object):
         # difference to data vector
         delta = self._data_vector - model_vector
         # evaluate likelihood
-        lnlikelihood = -delta.dot(cov_tot_inv.dot(delta)) / 2.
+        lnlikelihood = -delta.dot(cov_tot_inv.dot(delta)) / 2.0
         sign_det, lndet = np.linalg.slogdet(cov_tot)
-        lnlikelihood -= 1 / 2. * (self.num_data * np.log(2 * np.pi) + lndet)
+        lnlikelihood -= 1 / 2.0 * (self.num_data * np.log(2 * np.pi) + lndet)
         return lnlikelihood
 
     def _model_cov(self, ddt, mu_intrinsic):
@@ -79,9 +91,13 @@ class TDMagLikelihood(object):
         :return: model vector, combined covariance matrix
         """
         # compute model predicted magnified image amplitude and time delay
-        amp_intrinsic = magnitude2cps(magnitude=mu_intrinsic, magnitude_zero_point=self._magnitude_zero_point)
-        model_scale = np.append(ddt * self._fermat_unit_conversion * np.ones(self._n_td),
-                                amp_intrinsic * np.ones(self._n_amp))
+        amp_intrinsic = magnitude2cps(
+            magnitude=mu_intrinsic, magnitude_zero_point=self._magnitude_zero_point
+        )
+        model_scale = np.append(
+            ddt * self._fermat_unit_conversion * np.ones(self._n_td),
+            amp_intrinsic * np.ones(self._n_amp),
+        )
         model_vector = model_scale * self._model_tot
         # scale model covariance matrix with model_scale vector (in quadrature)
         cov_model = model_scale * (self._cov_model * model_scale).T

--- a/hierarc/Likelihood/LensLikelihood/td_mag_magnitude_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/td_mag_magnitude_likelihood.py
@@ -11,8 +11,16 @@ class TDMagMagnitudeLikelihood(object):
 
     """
 
-    def __init__(self, time_delay_measured, cov_td_measured, magnitude_measured, cov_magnitude_measured,
-                 fermat_diff, magnification_model, cov_model):
+    def __init__(
+        self,
+        time_delay_measured,
+        cov_td_measured,
+        magnitude_measured,
+        cov_magnitude_measured,
+        fermat_diff,
+        magnification_model,
+        cov_model,
+    ):
         """
 
         :param time_delay_measured: array, relative time delays (relative to the first image) [days]
@@ -38,10 +46,12 @@ class TDMagMagnitudeLikelihood(object):
         assert n_tot == len(cov_model)
         # merge data covariance matrices from time delay and image amplitudes
         self._cov_data = np.zeros((n_tot, n_tot))
-        self._cov_data[:self._n_td, :self._n_td] = self._cov_td_measured
-        self._cov_data[self._n_td:, self._n_td:] = self._cov_magnitude_measured
+        self._cov_data[: self._n_td, : self._n_td] = self._cov_td_measured
+        self._cov_data[self._n_td :, self._n_td :] = self._cov_magnitude_measured
         # self._fermat_diff = fermat_diff   # in units arcsec^2
-        self._fermat_unit_conversion = const.Mpc / const.c / const.day_s * const.arcsec ** 2
+        self._fermat_unit_conversion = (
+            const.Mpc / const.c / const.day_s * const.arcsec**2
+        )
         # self._mag_model = mag_model
         self._model_tot = np.append(fermat_diff, magnification_model)
         self._cov_model = cov_model
@@ -63,9 +73,9 @@ class TDMagMagnitudeLikelihood(object):
         # difference to data vector
         delta = self._data_vector - model_vector
         # evaluate likelihood
-        lnlikelihood = -delta.dot(cov_tot_inv.dot(delta)) / 2.
+        lnlikelihood = -delta.dot(cov_tot_inv.dot(delta)) / 2.0
         sign_det, lndet = np.linalg.slogdet(cov_tot)
-        lnlikelihood -= 1 / 2. * (self.num_data * np.log(2 * np.pi) + lndet)
+        lnlikelihood -= 1 / 2.0 * (self.num_data * np.log(2 * np.pi) + lndet)
         return lnlikelihood
 
     def _model_cov(self, ddt, mu_intrinsic):
@@ -79,12 +89,17 @@ class TDMagMagnitudeLikelihood(object):
         """
         # compute model predicted magnified image amplitude and time delay
 
-        model_scale = np.append(ddt * self._fermat_unit_conversion * np.ones(self._n_td), np.ones(self._n_amp))
+        model_scale = np.append(
+            ddt * self._fermat_unit_conversion * np.ones(self._n_td),
+            np.ones(self._n_amp),
+        )
         model_vector = np.zeros_like(self._model_tot)
         # time delay prediction
-        model_vector[:self._n_td] = ddt * self._fermat_unit_conversion * self._model_tot[:self._n_td]
+        model_vector[: self._n_td] = (
+            ddt * self._fermat_unit_conversion * self._model_tot[: self._n_td]
+        )
         # lensed astronomical magnitude prediction
-        model_vector[self._n_td:] = self._model_tot[self._n_td:] + mu_intrinsic
+        model_vector[self._n_td :] = self._model_tot[self._n_td :] + mu_intrinsic
         # scale model covariance matrix with model_scale vector (in quadrature),
         # shift in astronomical magnitudes do not change covariance matrix
         cov_model = model_scale * (self._cov_model * model_scale).T

--- a/hierarc/Likelihood/LensLikelihood/td_mag_magnitude_likelihood.py
+++ b/hierarc/Likelihood/LensLikelihood/td_mag_magnitude_likelihood.py
@@ -3,12 +3,10 @@ from lenstronomy.Util import constants as const
 
 
 class TDMagMagnitudeLikelihood(object):
-    """
-    likelihood of time delays and magnification likelihood
+    """Likelihood of time delays and magnification likelihood.
 
-    This likelihood uses astronomical magnitude units in flux measurement and lensing magnification
-    and Gaussian uncertainties in this space.
-
+    This likelihood uses astronomical magnitude units in flux measurement and lensing
+    magnification and Gaussian uncertainties in this space.
     """
 
     def __init__(
@@ -79,12 +77,12 @@ class TDMagMagnitudeLikelihood(object):
         return lnlikelihood
 
     def _model_cov(self, ddt, mu_intrinsic):
-        """
-        combined covariance matrix of the data and model when marginialized over the Gaussian model uncertainties
-        in the Fermat potential and magnification.
+        """Combined covariance matrix of the data and model when marginialized over the
+        Gaussian model uncertainties in the Fermat potential and magnification.
 
         :param ddt: time-delay distance (physical Mpc)
-        :param mu_intrinsic: intrinsic brightness of the source (already incorporating the inverse MST transform)
+        :param mu_intrinsic: intrinsic brightness of the source (already incorporating
+            the inverse MST transform)
         :return: model vector, combined covariance matrix
         """
         # compute model predicted magnified image amplitude and time delay

--- a/hierarc/Likelihood/SneLikelihood/sne_likelihood.py
+++ b/hierarc/Likelihood/SneLikelihood/sne_likelihood.py
@@ -1,6 +1,8 @@
 import numpy as np
 
-from hierarc.Likelihood.SneLikelihood.sne_likelihood_from_file import SneLikelihoodFromFile
+from hierarc.Likelihood.SneLikelihood.sne_likelihood_from_file import (
+    SneLikelihoodFromFile,
+)
 from hierarc.Likelihood.SneLikelihood.sne_likelihood_custom import CustomSneLikelihood
 from hierarc.Likelihood.SneLikelihood.sne_pantheon_plus import PantheonPlusData
 
@@ -10,24 +12,32 @@ class SneLikelihood(object):
     Supernovae likelihood
     This class supports custom likelihoods as well as likelihoods from the Pantheon sample from file
     """
-    def __init__(self, sample_name='CUSTOM', **kwargs_sne_likelihood):
+
+    def __init__(self, sample_name="CUSTOM", **kwargs_sne_likelihood):
         """
 
         :param sample_name: string, either 'CUSTOM' or a specific name supported by SneLikelihoodFromFile() class
         :param kwargs_sne_likelihood: keyword arguments to initiate likelihood class
         """
-        if sample_name == 'CUSTOM':
+        if sample_name == "CUSTOM":
             self._likelihood = CustomSneLikelihood(**kwargs_sne_likelihood)
-        elif sample_name == 'PantheonPlus':
-            from hierarc.Likelihood.SneLikelihood.sne_pantheon_plus import PantheonPlusData
+        elif sample_name == "PantheonPlus":
+            from hierarc.Likelihood.SneLikelihood.sne_pantheon_plus import (
+                PantheonPlusData,
+            )
+
             data = PantheonPlusData()
             mag_mean = data.m_obs
             cov_mag = data.cov_mag_b
             zhel = data.zHEL
             zcmb = data.zCMB
-            self._likelihood = CustomSneLikelihood(mag_mean, cov_mag, zhel, zcmb, no_intrinsic_scatter=True)
+            self._likelihood = CustomSneLikelihood(
+                mag_mean, cov_mag, zhel, zcmb, no_intrinsic_scatter=True
+            )
         else:
-            self._likelihood = SneLikelihoodFromFile(sample_name=sample_name, **kwargs_sne_likelihood)
+            self._likelihood = SneLikelihoodFromFile(
+                sample_name=sample_name, **kwargs_sne_likelihood
+            )
         self.zhel = self._likelihood.zhel
         self.zcmb = self._likelihood.zcmb
 
@@ -42,9 +52,15 @@ class SneLikelihood(object):
         :return: log likelihood of the data given the specified cosmology
         """
         angular_diameter_distances = cosmo.angular_diameter_distance(self.zcmb).value
-        lum_dists = (5 * np.log10((1 + self.zhel) * (1 + self.zcmb) * angular_diameter_distances))
+        lum_dists = 5 * np.log10(
+            (1 + self.zhel) * (1 + self.zcmb) * angular_diameter_distances
+        )
 
         ang_dist_anchor = cosmo.angular_diameter_distance(z_anchor).value
-        lum_dist_anchor = (5 * np.log10((1 + z_anchor) * (1 + z_anchor) * ang_dist_anchor))
+        lum_dist_anchor = 5 * np.log10(
+            (1 + z_anchor) * (1 + z_anchor) * ang_dist_anchor
+        )
 
-        return self._likelihood.log_likelihood_lum_dist(lum_dists - lum_dist_anchor, apparent_m_z, sigma_m_z)
+        return self._likelihood.log_likelihood_lum_dist(
+            lum_dists - lum_dist_anchor, apparent_m_z, sigma_m_z
+        )

--- a/hierarc/Likelihood/SneLikelihood/sne_likelihood.py
+++ b/hierarc/Likelihood/SneLikelihood/sne_likelihood.py
@@ -8,10 +8,8 @@ from hierarc.Likelihood.SneLikelihood.sne_pantheon_plus import PantheonPlusData
 
 
 class SneLikelihood(object):
-    """
-    Supernovae likelihood
-    This class supports custom likelihoods as well as likelihoods from the Pantheon sample from file
-    """
+    """Supernovae likelihood This class supports custom likelihoods as well as
+    likelihoods from the Pantheon sample from file."""
 
     def __init__(self, sample_name="CUSTOM", **kwargs_sne_likelihood):
         """

--- a/hierarc/Likelihood/SneLikelihood/sne_likelihood_custom.py
+++ b/hierarc/Likelihood/SneLikelihood/sne_likelihood_custom.py
@@ -28,7 +28,9 @@ class CustomSneLikelihood(object):
         self.num_sne = len(mag_mean)
         self._no_intrinsic_scatter = no_intrinsic_scatter
 
-    def log_likelihood_lum_dist(self, lum_dists, estimated_scriptm=None, sigma_m_z=None):
+    def log_likelihood_lum_dist(
+        self, lum_dists, estimated_scriptm=None, sigma_m_z=None
+    ):
         """
 
         :param lum_dists: numpy array of luminosity distances to the measured supernovae bins
@@ -48,9 +50,9 @@ class CustomSneLikelihood(object):
             estimated_scriptm = np.sum((self.mag - lum_dists) * invvars) / wtval
         diffmag = self.mag - lum_dists - estimated_scriptm
 
-        lnlikelihood = -diffmag.dot(inv_cov.dot(diffmag)) / 2.
+        lnlikelihood = -diffmag.dot(inv_cov.dot(diffmag)) / 2.0
         sign_det, lndet = np.linalg.slogdet(cov_mag)
-        lnlikelihood -= 1 / 2. * (self.num_sne * np.log(2 * np.pi) + lndet)
+        lnlikelihood -= 1 / 2.0 * (self.num_sne * np.log(2 * np.pi) + lndet)
         return lnlikelihood
 
     def _inverse_covariance_matrix(self, sigma_m_z=None):

--- a/hierarc/Likelihood/SneLikelihood/sne_likelihood_custom.py
+++ b/hierarc/Likelihood/SneLikelihood/sne_likelihood_custom.py
@@ -4,10 +4,9 @@ _twopi = 2 * np.pi
 
 
 class CustomSneLikelihood(object):
-    """
-    class method for an arbitrary apparent magnitude likelihood of a Sne sample where the error and systematic
-    covariance matrix is described in astronomical magnitude space
-    """
+    """Class method for an arbitrary apparent magnitude likelihood of a Sne sample where
+    the error and systematic covariance matrix is described in astronomical magnitude
+    space."""
 
     def __init__(self, mag_mean, cov_mag, zhel, zcmb, no_intrinsic_scatter=False):
         """
@@ -56,12 +55,11 @@ class CustomSneLikelihood(object):
         return lnlikelihood
 
     def _inverse_covariance_matrix(self, sigma_m_z=None):
-        """
-        inverse error covariance matrix. Combines redshift uncertainties (to first order) and magnitude uncertainties
-        as well as intrinsic scatter uncertainties
+        """Inverse error covariance matrix. Combines redshift uncertainties (to first
+        order) and magnitude uncertainties as well as intrinsic scatter uncertainties.
 
-        :param sigma_m_z: float, 1-sigma additional intrinsic magnitude uncertainty of the distribution, not
-        accounted-for in the original covariance matrix
+        :param sigma_m_z: float, 1-sigma additional intrinsic magnitude uncertainty of
+            the distribution, not accounted-for in the original covariance matrix
         :return: covariance matrix, inverse covariance matrix (2d numpy array)
         """
         # here is the option for adding an additional covariance matrix term of the calibration and/or systematic

--- a/hierarc/Likelihood/SneLikelihood/sne_likelihood_from_file.py
+++ b/hierarc/Likelihood/SneLikelihood/sne_likelihood_from_file.py
@@ -18,7 +18,7 @@ This likelihood does NOT include systematics!
 :Author: Alex Conley, Marc Betoule, Antony Lewis (see source for more specific authorship)
 
 """
-__author__ = 'sibirrer'
+__author__ = "sibirrer"
 
 # Global
 import numpy as np
@@ -28,50 +28,77 @@ import os
 import hierarc
 
 _twopi = 2 * np.pi
-_SAMPLE_NAME_SUPPORTED = ['Pantheon_binned', 'Pantheon', 'Roman_forecast']
-_PATH_2_DATA = os.path.join(os.path.dirname(hierarc.__file__), 'Data', 'SNe')
+_SAMPLE_NAME_SUPPORTED = ["Pantheon_binned", "Pantheon", "Roman_forecast"]
+_PATH_2_DATA = os.path.join(os.path.dirname(hierarc.__file__), "Data", "SNe")
 
 
 class SneLikelihoodFromFile(object):
     """
     Base likelihood class for evaluating Sne likelihoods
     """
-    def __init__(self, sample_name='Pantheon_binned', pec_z=0.001):
+
+    def __init__(self, sample_name="Pantheon_binned", pec_z=0.001):
         """
 
         :param sample_name: string, name of data sample
         :param pec_z: float, peculiar velocity in units of redshift (ignored when binned data products are used)
         """
         if sample_name not in _SAMPLE_NAME_SUPPORTED:
-            raise ValueError('Sample name %s not supported. Please chose the Sne sample name among %s.'
-                             % (sample_name, _SAMPLE_NAME_SUPPORTED))
-        if sample_name == 'Pantheon_binned':
-            self._data_file = os.path.join(_PATH_2_DATA, 'pantheon_binned_lcparam_DS17f.txt')
+            raise ValueError(
+                "Sample name %s not supported. Please chose the Sne sample name among %s."
+                % (sample_name, _SAMPLE_NAME_SUPPORTED)
+            )
+        if sample_name == "Pantheon_binned":
+            self._data_file = os.path.join(
+                _PATH_2_DATA, "pantheon_binned_lcparam_DS17f.txt"
+            )
             self._cov_file = None
             pec_z = 0
-        elif sample_name == 'Pantheon':
-            self._data_file = os.path.join(_PATH_2_DATA, 'pantheon_lcparam_full_long_zhel.txt')
-            self._cov_file = os.path.join(_PATH_2_DATA, 'pantheon_sys_full_long.txt')
-        elif sample_name == 'Roman_forecast':
-            self._data_file = os.path.join(_PATH_2_DATA, 'RomanWFIRST', 'lcparam_WFIRST_G10.txt')
-            self._cov_file = os.path.join(_PATH_2_DATA, 'RomanWFIRST', 'sys_WFIRST_G10_0.txt')
+        elif sample_name == "Pantheon":
+            self._data_file = os.path.join(
+                _PATH_2_DATA, "pantheon_lcparam_full_long_zhel.txt"
+            )
+            self._cov_file = os.path.join(_PATH_2_DATA, "pantheon_sys_full_long.txt")
+        elif sample_name == "Roman_forecast":
+            self._data_file = os.path.join(
+                _PATH_2_DATA, "RomanWFIRST", "lcparam_WFIRST_G10.txt"
+            )
+            self._cov_file = os.path.join(
+                _PATH_2_DATA, "RomanWFIRST", "sys_WFIRST_G10_0.txt"
+            )
 
         self._pec_z = pec_z
         cols = None
 
         self.names = []
         ix = 0
-        with open(self._data_file, 'r') as f:
+        with open(self._data_file, "r") as f:
             lines = f.readlines()
             for line in lines:
-                if '#' in line:
+                if "#" in line:
                     cols = line[1:].split()
                     for rename, new in zip(
-                            ['mb', 'color', 'x1', '3rdvar', 'd3rdvar',
-                             'cov_m_s', 'cov_m_c', 'cov_s_c'],
-                            ['mag', 'colour', 'stretch', 'third_var',
-                             'dthird_var', 'cov_mag_stretch',
-                             'cov_mag_colour', 'cov_stretch_colour']):
+                        [
+                            "mb",
+                            "color",
+                            "x1",
+                            "3rdvar",
+                            "d3rdvar",
+                            "cov_m_s",
+                            "cov_m_c",
+                            "cov_s_c",
+                        ],
+                        [
+                            "mag",
+                            "colour",
+                            "stretch",
+                            "third_var",
+                            "dthird_var",
+                            "cov_mag_stretch",
+                            "cov_mag_colour",
+                            "cov_stretch_colour",
+                        ],
+                    ):
                         if rename in cols:
                             cols[cols.index(rename)] = new
 
@@ -80,22 +107,23 @@ class SneLikelihoodFromFile(object):
                     for col in cols:
                         setattr(self, col, zeros.copy())
                 elif line.strip():
-                    if cols is None: raise ImportError('Data file must have comment header')
+                    if cols is None:
+                        raise ImportError("Data file must have comment header")
                     vals = line.split()
                     for i, (col, val) in enumerate(zip(cols, vals)):
-                        if col == 'name':
+                        if col == "name":
                             self.names.append(val)
                         else:
                             getattr(self, col)[ix] = np.float64(val)
                     ix += 1
         # Check whether required instances are read in
-        assert hasattr(self, 'dz')
+        assert hasattr(self, "dz")
         # TODO: make read-in such that the arguments required are explicitly matched ('zcmb', 'zhel', 'dz', 'mag', 'dmb')
         # spectroscopic redshift error. ATTENTION! This value =0 for binned data. In this code the value is not used.
         # Cobaya also does not use it!
-        self.z_var = self.dz ** 2
+        self.z_var = self.dz**2
         # variance in the bolometric magnitude distribution of the same for the redshift and type of the SNe
-        self.mag_var = self.dmb ** 2
+        self.mag_var = self.dmb**2
 
         self.nsn = ix
         self._cov = read_covariance_matrix(self._cov_file, self.nsn)
@@ -103,8 +131,12 @@ class SneLikelihoodFromFile(object):
         # jla_prep
         zfacsq = 25.0 / np.log(10.0) ** 2
         # adding peculiar redshift uncertainties to be added to the diagonal variance elements of the covariance matrix
-        self.diag_uncorr_errors = self.mag_var + zfacsq * self._pec_z ** 2 * (
-                (1.0 + self.zcmb) / (self.zcmb * (1 + 0.5 * self.zcmb))) ** 2
+        self.diag_uncorr_errors = (
+            self.mag_var
+            + zfacsq
+            * self._pec_z**2
+            * ((1.0 + self.zcmb) / (self.zcmb * (1 + 0.5 * self.zcmb))) ** 2
+        )
 
         self._inv_cov = self._inverse_covariance_matrix()
 
@@ -117,14 +149,18 @@ class SneLikelihoodFromFile(object):
         # here is the option for adding an additional covariance matrix term of the calibration and/or systematic
         # errors in the evolution of the Sne population
         cov = self._cov
-        cov_diag = cov.diagonal()  # if invcovmat is a matrix, then this is invcovmat.diagonal()
+        cov_diag = (
+            cov.diagonal()
+        )  # if invcovmat is a matrix, then this is invcovmat.diagonal()
 
         delta = self.diag_uncorr_errors
         np.fill_diagonal(cov, cov_diag + delta)
         invcov = np.linalg.inv(cov)
         return invcov
 
-    def log_likelihood_lum_dist(self, lum_dists, estimated_scriptm=None, sigma_m_z=None):
+    def log_likelihood_lum_dist(
+        self, lum_dists, estimated_scriptm=None, sigma_m_z=None
+    ):
         """
 
         :param lum_dists: numpy array of luminosity distances to the measured supernovae bins
@@ -150,7 +186,7 @@ class SneLikelihoodFromFile(object):
         amarg_E = np.sum(invcovmat)
         chi2 = amarg_A + np.log(amarg_E / _twopi)  # - amarg_B ** 2 / amarg_E
 
-        return - chi2 / 2
+        return -chi2 / 2
 
 
 def read_covariance_matrix(filename, nsn):

--- a/hierarc/Likelihood/SneLikelihood/sne_likelihood_from_file.py
+++ b/hierarc/Likelihood/SneLikelihood/sne_likelihood_from_file.py
@@ -33,9 +33,7 @@ _PATH_2_DATA = os.path.join(os.path.dirname(hierarc.__file__), "Data", "SNe")
 
 
 class SneLikelihoodFromFile(object):
-    """
-    Base likelihood class for evaluating Sne likelihoods
-    """
+    """Base likelihood class for evaluating Sne likelihoods."""
 
     def __init__(self, sample_name="Pantheon_binned", pec_z=0.001):
         """
@@ -141,8 +139,8 @@ class SneLikelihoodFromFile(object):
         self._inv_cov = self._inverse_covariance_matrix()
 
     def _inverse_covariance_matrix(self):
-        """
-        inverse error covariance matrix. Combines redshift uncertainties (to first order) and magnitude uncertainties
+        """Inverse error covariance matrix. Combines redshift uncertainties (to first
+        order) and magnitude uncertainties.
 
         :return: inverse covariance matrix (2d numpy array)
         """
@@ -190,8 +188,7 @@ class SneLikelihoodFromFile(object):
 
 
 def read_covariance_matrix(filename, nsn):
-    """
-    reads in covariance matrix file and returns it as a numpy matrix
+    """Reads in covariance matrix file and returns it as a numpy matrix.
 
     :param filename: string, absolute path of covariance matrix file
     :param nsn: number of supernovae (or bins)

--- a/hierarc/Likelihood/SneLikelihood/sne_pantheon_plus.py
+++ b/hierarc/Likelihood/SneLikelihood/sne_pantheon_plus.py
@@ -3,7 +3,7 @@ import pandas as pd
 import numpy as np
 import hierarc
 
-_PATH_2_DATA = os.path.join(os.path.dirname(hierarc.__file__), 'Data', 'SNe')
+_PATH_2_DATA = os.path.join(os.path.dirname(hierarc.__file__), "Data", "SNe")
 
 
 class PantheonPlusData(object):
@@ -21,17 +21,23 @@ class PantheonPlusData(object):
     """
 
     def __init__(self):
-        self._data_file = os.path.join(_PATH_2_DATA, 'Pantheon+SH0ES', 'Pantheon+SH0ES.dat')
-        self._cov_file = os.path.join(_PATH_2_DATA, 'Pantheon+SH0ES', 'Pantheon+SH0ES_STAT+SYS.cov')
+        self._data_file = os.path.join(
+            _PATH_2_DATA, "Pantheon+SH0ES", "Pantheon+SH0ES.dat"
+        )
+        self._cov_file = os.path.join(
+            _PATH_2_DATA, "Pantheon+SH0ES", "Pantheon+SH0ES_STAT+SYS.cov"
+        )
 
         data = pd.read_csv(self._data_file, delim_whitespace=True)
         self.origlen = len(data)
 
-        self.ww = (data['zHD'] > 0.01)
+        self.ww = data["zHD"] > 0.01
 
-        self.zCMB = data['zHD'][self.ww].to_numpy()  # use the vpec corrected redshift for zCMB
-        self.zHEL = data['zHEL'][self.ww].to_numpy()
-        self.m_obs = data['m_b_corr'][self.ww].to_numpy()
+        self.zCMB = data["zHD"][
+            self.ww
+        ].to_numpy()  # use the vpec corrected redshift for zCMB
+        self.zHEL = data["zHEL"][self.ww].to_numpy()
+        self.m_obs = data["m_b_corr"][self.ww].to_numpy()
 
         self.cov_mag_b = self.build_covariance()
 

--- a/hierarc/Likelihood/SneLikelihood/sne_pantheon_plus.py
+++ b/hierarc/Likelihood/SneLikelihood/sne_pantheon_plus.py
@@ -7,8 +7,8 @@ _PATH_2_DATA = os.path.join(os.path.dirname(hierarc.__file__), "Data", "SNe")
 
 
 class PantheonPlusData(object):
-    """
-    This class is a lightweight version of the Pantheon+ analysis presented in `Pantheon+ likelihood`_.
+    """This class is a lightweight version of the Pantheon+ analysis presented in
+    `Pantheon+ likelihood`_.
 
     The data covariances that are stored in hierArc are originally from `Pantheon+ Data products`_.
 
@@ -17,7 +17,6 @@ class PantheonPlusData(object):
     .. _Brout et al. 2022: https://ui.adsabs.harvard.edu/abs/2022arXiv220204077B/abstract
     .. _Pantheon+ Data products: https://github.com/PantheonPlusSH0ES/DataRelease/tree/main/Pantheon%2B_Data/4_DISTANCES_AND_COVAR
     .. _Pantheon+ likelihood: https://github.com/PantheonPlusSH0ES/DataRelease/blob/main/Pantheon%2B_Data/5_COSMOLOGY/cosmosis_likelihoods/Pantheon%2B_only_cosmosis_likelihood.py
-
     """
 
     def __init__(self):
@@ -42,7 +41,7 @@ class PantheonPlusData(object):
         self.cov_mag_b = self.build_covariance()
 
     def build_covariance(self):
-        """Run once at the start to build the covariance matrix for the data"""
+        """Run once at the start to build the covariance matrix for the data."""
         filename = self._cov_file
 
         # The file format for the covariance has the first line as an integer

--- a/hierarc/Likelihood/anisotropy_scaling.py
+++ b/hierarc/Likelihood/anisotropy_scaling.py
@@ -4,9 +4,7 @@ import numpy as np
 
 
 class AnisotropyScalingSingleAperture(object):
-    """
-    class to manage anisotropy scaling for single slit observation
-    """
+    """Class to manage anisotropy scaling for single slit observation."""
 
     def __init__(self, ani_param_array, ani_scaling_array):
         """
@@ -50,9 +48,7 @@ class AnisotropyScalingSingleAperture(object):
 
 
 class AnisotropyScalingIFU(object):
-    """
-    class to manage anisotropy scalings for IFU data
-    """
+    """Class to manage anisotropy scalings for IFU data."""
 
     def __init__(
         self, anisotropy_model="NONE", ani_param_array=None, ani_scaling_array_list=None
@@ -114,8 +110,7 @@ class AnisotropyScalingIFU(object):
     def draw_anisotropy(
         self, a_ani=None, a_ani_sigma=0, beta_inf=None, beta_inf_sigma=0
     ):
-        """
-        draw Gaussian distribution and re-sample if outside bounds
+        """Draw Gaussian distribution and re-sample if outside bounds.
 
         :param a_ani: mean of the distribution
         :param a_ani_sigma: std of the distribution

--- a/hierarc/Likelihood/anisotropy_scaling.py
+++ b/hierarc/Likelihood/anisotropy_scaling.py
@@ -1,4 +1,4 @@
-__author__ = 'sibirrer'
+__author__ = "sibirrer"
 from scipy.interpolate import interp1d, interp2d
 import numpy as np
 
@@ -21,11 +21,18 @@ class AnisotropyScalingSingleAperture(object):
             else:
                 self._dim_scaling = 1
             if self._dim_scaling == 1:
-                self._f_ani = interp1d(ani_param_array, ani_scaling_array, kind='linear')
+                self._f_ani = interp1d(
+                    ani_param_array, ani_scaling_array, kind="linear"
+                )
             elif self._dim_scaling == 2:
-                self._f_ani = interp2d(ani_param_array[0], ani_param_array[1], ani_scaling_array.T)
+                self._f_ani = interp2d(
+                    ani_param_array[0], ani_param_array[1], ani_scaling_array.T
+                )
             else:
-                raise ValueError('anisotropy scaling with dimension %s not supported.' % self._dim_scaling)
+                raise ValueError(
+                    "anisotropy scaling with dimension %s not supported."
+                    % self._dim_scaling
+                )
             self._evalute_ani = True
 
     def ani_scaling(self, aniso_param_array):
@@ -47,7 +54,9 @@ class AnisotropyScalingIFU(object):
     class to manage anisotropy scalings for IFU data
     """
 
-    def __init__(self, anisotropy_model='NONE', ani_param_array=None, ani_scaling_array_list=None):
+    def __init__(
+        self, anisotropy_model="NONE", ani_param_array=None, ani_scaling_array_list=None
+    ):
         """
 
         :param anisotropy_model: string, either 'NONE', 'OM' or 'GOM'
@@ -56,27 +65,37 @@ class AnisotropyScalingIFU(object):
         """
         self._anisotropy_model = anisotropy_model
         self._evalute_ani = False
-        if ani_param_array is not None and ani_scaling_array_list is not None and self._anisotropy_model != 'NONE':
+        if (
+            ani_param_array is not None
+            and ani_scaling_array_list is not None
+            and self._anisotropy_model != "NONE"
+        ):
             self._evalute_ani = True
             self._anisotropy_scaling_list = []
             self._f_ani_list = []
             for ani_scaling_array in ani_scaling_array_list:
-                self._anisotropy_scaling_list.append(AnisotropyScalingSingleAperture(ani_param_array=ani_param_array,
-                                                                                     ani_scaling_array=ani_scaling_array))
+                self._anisotropy_scaling_list.append(
+                    AnisotropyScalingSingleAperture(
+                        ani_param_array=ani_param_array,
+                        ani_scaling_array=ani_scaling_array,
+                    )
+                )
 
             if isinstance(ani_param_array, list):
                 self._dim_scaling = len(ani_param_array)
             else:
                 self._dim_scaling = 1
-            if self._dim_scaling == 1 and anisotropy_model in ['OM', 'const']:
+            if self._dim_scaling == 1 and anisotropy_model in ["OM", "const"]:
                 self._ani_param_min = np.min(ani_param_array)
                 self._ani_param_max = np.max(ani_param_array)
-            elif self._dim_scaling == 2 and anisotropy_model == 'GOM':
+            elif self._dim_scaling == 2 and anisotropy_model == "GOM":
                 self._ani_param_min = [min(ani_param_array[0]), min(ani_param_array[1])]
                 self._ani_param_max = [max(ani_param_array[0]), max(ani_param_array[1])]
             else:
-                raise ValueError('anisotropy scaling with dimension %s does not match anisotropy model %s'
-                                 % (self._dim_scaling, self._anisotropy_model))
+                raise ValueError(
+                    "anisotropy scaling with dimension %s does not match anisotropy model %s"
+                    % (self._dim_scaling, self._anisotropy_model)
+                )
 
     def ani_scaling(self, aniso_param_array):
         """
@@ -92,7 +111,9 @@ class AnisotropyScalingIFU(object):
             scaling_list.append(scaling)
         return np.array(scaling_list)
 
-    def draw_anisotropy(self, a_ani=None, a_ani_sigma=0, beta_inf=None, beta_inf_sigma=0):
+    def draw_anisotropy(
+        self, a_ani=None, a_ani_sigma=0, beta_inf=None, beta_inf_sigma=0
+    ):
         """
         draw Gaussian distribution and re-sample if outside bounds
 
@@ -102,23 +123,39 @@ class AnisotropyScalingIFU(object):
         :param beta_inf_sigma: std of beta_inf distribution
         :return: random draw from the distribution
         """
-        if self._anisotropy_model in ['OM', 'const']:
+        if self._anisotropy_model in ["OM", "const"]:
             if a_ani < self._ani_param_min or a_ani > self._ani_param_max:
-                raise ValueError('anisotropy parameter is out of bounds of the interpolated range!')
+                raise ValueError(
+                    "anisotropy parameter is out of bounds of the interpolated range!"
+                )
             # we draw a linear gaussian for 'const' anisotropy and a scaled proportional one for 'OM
-            if self._anisotropy_model == 'OM':
-                a_ani_draw = np.random.normal(a_ani, a_ani_sigma*a_ani)
+            if self._anisotropy_model == "OM":
+                a_ani_draw = np.random.normal(a_ani, a_ani_sigma * a_ani)
             else:
                 a_ani_draw = np.random.normal(a_ani, a_ani_sigma)
             if a_ani_draw < self._ani_param_min or a_ani_draw > self._ani_param_max:
                 return self.draw_anisotropy(a_ani, a_ani_sigma)
             return np.array([a_ani_draw])
-        elif self._anisotropy_model in ['GOM']:
-            if a_ani < self._ani_param_min[0] or a_ani > self._ani_param_max[0] or beta_inf < self._ani_param_min[1] or beta_inf > self._ani_param_max[1]:
-                raise ValueError('anisotropy parameter is out of bounds of the interpolated range!')
-            a_ani_draw = np.random.normal(a_ani, a_ani_sigma*a_ani)
+        elif self._anisotropy_model in ["GOM"]:
+            if (
+                a_ani < self._ani_param_min[0]
+                or a_ani > self._ani_param_max[0]
+                or beta_inf < self._ani_param_min[1]
+                or beta_inf > self._ani_param_max[1]
+            ):
+                raise ValueError(
+                    "anisotropy parameter is out of bounds of the interpolated range!"
+                )
+            a_ani_draw = np.random.normal(a_ani, a_ani_sigma * a_ani)
             beta_inf_draw = np.random.normal(beta_inf, beta_inf_sigma)
-            if a_ani_draw < self._ani_param_min[0] or a_ani_draw > self._ani_param_max[0] or beta_inf_draw < self._ani_param_min[1] or beta_inf_draw > self._ani_param_max[1]:
-                return self.draw_anisotropy(a_ani, a_ani_sigma, beta_inf, beta_inf_sigma)
+            if (
+                a_ani_draw < self._ani_param_min[0]
+                or a_ani_draw > self._ani_param_max[0]
+                or beta_inf_draw < self._ani_param_min[1]
+                or beta_inf_draw > self._ani_param_max[1]
+            ):
+                return self.draw_anisotropy(
+                    a_ani, a_ani_sigma, beta_inf, beta_inf_sigma
+                )
             return np.array([a_ani_draw, beta_inf_draw])
         return None

--- a/hierarc/Likelihood/cosmo_likelihood.py
+++ b/hierarc/Likelihood/cosmo_likelihood.py
@@ -12,17 +12,38 @@ class CosmoLikelihood(object):
     this class contains the likelihood function of the Strong lensing analysis
     """
 
-    def __init__(self, kwargs_likelihood_list, cosmology, kwargs_bounds, sne_likelihood=None,
-                 kwargs_sne_likelihood=None, KDE_likelihood_chain=None, kwargs_kde_likelihood=None,
-                 ppn_sampling=False,
-                 lambda_mst_sampling=False, lambda_mst_distribution='delta', anisotropy_sampling=False,
-                 kappa_ext_sampling=False, kappa_ext_distribution='NONE',
-                 alpha_lambda_sampling=False, beta_lambda_sampling=False,
-                 lambda_ifu_sampling=False, lambda_ifu_distribution='NONE', sigma_v_systematics=False,
-                 sne_apparent_m_sampling=False, sne_distribution='GAUSSIAN', z_apparent_m_anchor=0.1,
-                 log_scatter=False, normalized=False,
-                 anisotropy_model='OM', anisotropy_distribution='NONE', custom_prior=None, interpolate_cosmo=True,
-                 num_redshift_interp=100, cosmo_fixed=None):
+    def __init__(
+        self,
+        kwargs_likelihood_list,
+        cosmology,
+        kwargs_bounds,
+        sne_likelihood=None,
+        kwargs_sne_likelihood=None,
+        KDE_likelihood_chain=None,
+        kwargs_kde_likelihood=None,
+        ppn_sampling=False,
+        lambda_mst_sampling=False,
+        lambda_mst_distribution="delta",
+        anisotropy_sampling=False,
+        kappa_ext_sampling=False,
+        kappa_ext_distribution="NONE",
+        alpha_lambda_sampling=False,
+        beta_lambda_sampling=False,
+        lambda_ifu_sampling=False,
+        lambda_ifu_distribution="NONE",
+        sigma_v_systematics=False,
+        sne_apparent_m_sampling=False,
+        sne_distribution="GAUSSIAN",
+        z_apparent_m_anchor=0.1,
+        log_scatter=False,
+        normalized=False,
+        anisotropy_model="OM",
+        anisotropy_distribution="NONE",
+        custom_prior=None,
+        interpolate_cosmo=True,
+        num_redshift_interp=100,
+        cosmo_fixed=None,
+    ):
         """
 
         :param kwargs_likelihood_list: keyword argument list specifying the arguments of the LensLikelihood class
@@ -76,20 +97,30 @@ class CosmoLikelihood(object):
         self._kwargs_lens_list = kwargs_likelihood_list
         if sigma_v_systematics is True:
             normalized = True
-        self._likelihoodLensSample = LensSampleLikelihood(kwargs_likelihood_list, normalized=normalized)
-        self.param = ParamManager(cosmology, ppn_sampling=ppn_sampling, lambda_mst_sampling=lambda_mst_sampling,
-                                  lambda_mst_distribution=lambda_mst_distribution,
-                                  lambda_ifu_sampling=lambda_ifu_sampling,
-                                  lambda_ifu_distribution=lambda_ifu_distribution,
-                                  alpha_lambda_sampling=alpha_lambda_sampling,
-                                  beta_lambda_sampling=beta_lambda_sampling,
-                                  sne_apparent_m_sampling=sne_apparent_m_sampling,
-                                  sne_distribution=sne_distribution, z_apparent_m_anchor=z_apparent_m_anchor,
-                                  sigma_v_systematics=sigma_v_systematics,
-                                  kappa_ext_sampling=kappa_ext_sampling, kappa_ext_distribution=kappa_ext_distribution,
-                                  anisotropy_sampling=anisotropy_sampling, anisotropy_model=anisotropy_model,
-                                  anisotropy_distribution=anisotropy_distribution, log_scatter=log_scatter,
-                                  **kwargs_bounds)
+        self._likelihoodLensSample = LensSampleLikelihood(
+            kwargs_likelihood_list, normalized=normalized
+        )
+        self.param = ParamManager(
+            cosmology,
+            ppn_sampling=ppn_sampling,
+            lambda_mst_sampling=lambda_mst_sampling,
+            lambda_mst_distribution=lambda_mst_distribution,
+            lambda_ifu_sampling=lambda_ifu_sampling,
+            lambda_ifu_distribution=lambda_ifu_distribution,
+            alpha_lambda_sampling=alpha_lambda_sampling,
+            beta_lambda_sampling=beta_lambda_sampling,
+            sne_apparent_m_sampling=sne_apparent_m_sampling,
+            sne_distribution=sne_distribution,
+            z_apparent_m_anchor=z_apparent_m_anchor,
+            sigma_v_systematics=sigma_v_systematics,
+            kappa_ext_sampling=kappa_ext_sampling,
+            kappa_ext_distribution=kappa_ext_distribution,
+            anisotropy_sampling=anisotropy_sampling,
+            anisotropy_model=anisotropy_model,
+            anisotropy_distribution=anisotropy_distribution,
+            log_scatter=log_scatter,
+            **kwargs_bounds
+        )
         self._lower_limit, self._upper_limit = self.param.param_bounds
         self._prior_add = False
         if custom_prior is not None:
@@ -102,7 +133,9 @@ class CosmoLikelihood(object):
         if sne_likelihood is not None:
             if kwargs_sne_likelihood is None:
                 kwargs_sne_likelihood = {}
-            self._sne_likelihood = SneLikelihood(sample_name=sne_likelihood, **kwargs_sne_likelihood)
+            self._sne_likelihood = SneLikelihood(
+                sample_name=sne_likelihood, **kwargs_sne_likelihood
+            )
             z_max = np.max(self._sne_likelihood.zcmb)
             self._sne_evaluate = True
         else:
@@ -111,19 +144,21 @@ class CosmoLikelihood(object):
         if KDE_likelihood_chain is not None:
             if kwargs_kde_likelihood is None:
                 kwargs_kde_likelihood = {}
-            self._kde_likelihood = KDELikelihood(KDE_likelihood_chain, **kwargs_kde_likelihood)
+            self._kde_likelihood = KDELikelihood(
+                KDE_likelihood_chain, **kwargs_kde_likelihood
+            )
             self._kde_evaluate = True
             self._chain_params = self._kde_likelihood.chain.list_params()
         else:
             self._kde_evaluate = False
 
         for kwargs_lens in kwargs_likelihood_list:
-            if 'z_source' in kwargs_lens:
-                if kwargs_lens['z_source'] > z_max:
-                    z_max = kwargs_lens['z_source']
-            if 'z_source_2' in kwargs_lens:
-                if kwargs_lens['z_source_2'] > z_max:
-                    z_max = kwargs_lens['z_source_2']
+            if "z_source" in kwargs_lens:
+                if kwargs_lens["z_source"] > z_max:
+                    z_max = kwargs_lens["z_source"]
+            if "z_source_2" in kwargs_lens:
+                if kwargs_lens["z_source_2"] > z_max:
+                    z_max = kwargs_lens["z_source_2"]
         self._z_max = z_max
 
     def likelihood(self, args, kwargs_cosmo_interp=None):
@@ -139,15 +174,17 @@ class CosmoLikelihood(object):
             if args[i] < self._lower_limit[i] or args[i] > self._upper_limit[i]:
                 return -np.inf
 
-        kwargs_cosmo, kwargs_lens, kwargs_kin, kwargs_source = self.param.args2kwargs(args)
+        kwargs_cosmo, kwargs_lens, kwargs_kin, kwargs_source = self.param.args2kwargs(
+            args
+        )
         if self._cosmology == "oLCDM":
             # assert we are not in a crazy cosmological situation that prevents computing the angular distance integral
-            h0, ok, om = kwargs_cosmo['h0'], kwargs_cosmo['ok'], kwargs_cosmo['om']
+            h0, ok, om = kwargs_cosmo["h0"], kwargs_cosmo["ok"], kwargs_cosmo["om"]
             for lens in self._kwargs_lens_list:
-                if 'z_source' in lens:
-                    z = lens['z_source']
-                elif 'z_source_2' in lens:
-                    z = lens['z_source_2']
+                if "z_source" in lens:
+                    z = lens["z_source"]
+                elif "z_source_2" in lens:
+                    z = lens["z_source_2"]
                 else:
                     z = 1100
                 cut = ok * (1.0 + z) ** 2 + om * (1.0 + z) ** 3 + (1.0 - om - ok)
@@ -159,23 +196,34 @@ class CosmoLikelihood(object):
         if kwargs_cosmo_interp is not None:
             kwargs_cosmo = {**kwargs_cosmo, **kwargs_cosmo_interp}
         cosmo = self.cosmo_instance(kwargs_cosmo)
-        log_l = self._likelihoodLensSample.log_likelihood(cosmo=cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin,
-                                                          kwargs_source=kwargs_source)
+        log_l = self._likelihoodLensSample.log_likelihood(
+            cosmo=cosmo,
+            kwargs_lens=kwargs_lens,
+            kwargs_kin=kwargs_kin,
+            kwargs_source=kwargs_source,
+        )
 
         if self._sne_evaluate is True:
-            apparent_m_z = kwargs_source.get('mu_sne', None)
-            z_apparent_m_anchor = kwargs_source['z_apparent_m_anchor']
-            sigma_m_z = kwargs_source.get('sigma_sne', None)
-            log_l += self._sne_likelihood.log_likelihood(cosmo=cosmo, apparent_m_z=apparent_m_z,
-                                                         z_anchor=z_apparent_m_anchor, sigma_m_z=sigma_m_z)
+            apparent_m_z = kwargs_source.get("mu_sne", None)
+            z_apparent_m_anchor = kwargs_source["z_apparent_m_anchor"]
+            sigma_m_z = kwargs_source.get("sigma_sne", None)
+            log_l += self._sne_likelihood.log_likelihood(
+                cosmo=cosmo,
+                apparent_m_z=apparent_m_z,
+                z_anchor=z_apparent_m_anchor,
+                sigma_m_z=sigma_m_z,
+            )
         if self._kde_evaluate is True:
             # all chain_params must be in the kwargs_cosmo
             cosmo_params = np.array([[kwargs_cosmo[k] for k in self._chain_params]])
-            cosmo_params = rescale_vector_to_unity(cosmo_params, self._kde_likelihood.chain.rescale_dic,
-                                                   self._chain_params)
+            cosmo_params = rescale_vector_to_unity(
+                cosmo_params, self._kde_likelihood.chain.rescale_dic, self._chain_params
+            )
             log_l += self._kde_likelihood.kdelikelihood_samples(cosmo_params)[0]
         if self._prior_add is True:
-            log_l += self._custom_prior(kwargs_cosmo, kwargs_lens, kwargs_kin, kwargs_source)
+            log_l += self._custom_prior(
+                kwargs_cosmo, kwargs_lens, kwargs_kin, kwargs_source
+            )
         return log_l
 
     def cosmo_instance(self, kwargs_cosmo):
@@ -184,22 +232,33 @@ class CosmoLikelihood(object):
         :param kwargs_cosmo: cosmology parameter keyword argument list
         :return: astropy.cosmology (or equivalent interpolation scheme class)
         """
-        if hasattr(kwargs_cosmo, 'ang_diameter_distances') and hasattr(kwargs_cosmo, 'redshifts'):
+        if hasattr(kwargs_cosmo, "ang_diameter_distances") and hasattr(
+            kwargs_cosmo, "redshifts"
+        ):
             # in that case we use directly the interpolation mode to approximate angular diameter distances
-            cosmo = CosmoInterp(ang_dist_list=kwargs_cosmo['ang_diameter_distances'],
-                                z_list=kwargs_cosmo['redshifts'],
-                                Ok0=kwargs_cosmo.get('ok', 0),
-                                K=kwargs_cosmo.get('K', None))
+            cosmo = CosmoInterp(
+                ang_dist_list=kwargs_cosmo["ang_diameter_distances"],
+                z_list=kwargs_cosmo["redshifts"],
+                Ok0=kwargs_cosmo.get("ok", 0),
+                K=kwargs_cosmo.get("K", None),
+            )
             return cosmo
         if self._cosmo_fixed is None:
             cosmo = self.param.cosmo(kwargs_cosmo)
             if self._interpolate_cosmo is True:
-                cosmo = CosmoInterp(cosmo=cosmo, z_stop=self._z_max, num_interp=self._num_redshift_interp)
+                cosmo = CosmoInterp(
+                    cosmo=cosmo,
+                    z_stop=self._z_max,
+                    num_interp=self._num_redshift_interp,
+                )
         else:
             if self._interpolate_cosmo is True:
-                if not hasattr(self, '_cosmo_fixed_interp'):
-                    self._cosmo_fixed_interp = CosmoInterp(cosmo=self._cosmo_fixed, z_stop=self._z_max,
-                                                           num_interp=self._num_redshift_interp)
+                if not hasattr(self, "_cosmo_fixed_interp"):
+                    self._cosmo_fixed_interp = CosmoInterp(
+                        cosmo=self._cosmo_fixed,
+                        z_stop=self._z_max,
+                        num_interp=self._num_redshift_interp,
+                    )
                 cosmo = self._cosmo_fixed_interp
             else:
                 cosmo = self._cosmo_fixed

--- a/hierarc/Likelihood/cosmo_likelihood.py
+++ b/hierarc/Likelihood/cosmo_likelihood.py
@@ -8,9 +8,7 @@ import numpy as np
 
 
 class CosmoLikelihood(object):
-    """
-    this class contains the likelihood function of the Strong lensing analysis
-    """
+    """This class contains the likelihood function of the Strong lensing analysis."""
 
     def __init__(
         self,

--- a/hierarc/Likelihood/hierarchy_likelihood.py
+++ b/hierarc/Likelihood/hierarchy_likelihood.py
@@ -10,11 +10,28 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
     """
     master class containing the likelihood definitions of different analysis for s single lens
     """
-    def __init__(self, z_lens, z_source, name='name', likelihood_type='TDKin', anisotropy_model='NONE',
-                 ani_param_array=None, ani_scaling_array_list=None, ani_scaling_array=None,
-                 num_distribution_draws=50, kappa_ext_bias=False, kappa_pdf=None, kappa_bin_edges=None, mst_ifu=False,
-                 lambda_scaling_property=0, lambda_scaling_property_beta=0,
-                 normalized=True, kwargs_lens_properties=None, **kwargs_likelihood):
+
+    def __init__(
+        self,
+        z_lens,
+        z_source,
+        name="name",
+        likelihood_type="TDKin",
+        anisotropy_model="NONE",
+        ani_param_array=None,
+        ani_scaling_array_list=None,
+        ani_scaling_array=None,
+        num_distribution_draws=50,
+        kappa_ext_bias=False,
+        kappa_pdf=None,
+        kappa_bin_edges=None,
+        mst_ifu=False,
+        lambda_scaling_property=0,
+        lambda_scaling_property_beta=0,
+        normalized=True,
+        kwargs_lens_properties=None,
+        **kwargs_likelihood
+    ):
         """
 
         :param z_lens: lens redshift
@@ -49,23 +66,38 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         TransformedCosmography.__init__(self, z_lens=z_lens, z_source=z_source)
         if ani_scaling_array_list is None and ani_scaling_array is not None:
             ani_scaling_array_list = [ani_scaling_array]
-        AnisotropyScalingIFU.__init__(self, anisotropy_model=anisotropy_model, ani_param_array=ani_param_array,
-                                      ani_scaling_array_list=ani_scaling_array_list)
-        LensLikelihoodBase.__init__(self, z_lens=z_lens, z_source=z_source, likelihood_type=likelihood_type, name=name,
-                                    normalized=normalized, kwargs_lens_properties=kwargs_lens_properties,
-                                    **kwargs_likelihood)
+        AnisotropyScalingIFU.__init__(
+            self,
+            anisotropy_model=anisotropy_model,
+            ani_param_array=ani_param_array,
+            ani_scaling_array_list=ani_scaling_array_list,
+        )
+        LensLikelihoodBase.__init__(
+            self,
+            z_lens=z_lens,
+            z_source=z_source,
+            likelihood_type=likelihood_type,
+            name=name,
+            normalized=normalized,
+            kwargs_lens_properties=kwargs_lens_properties,
+            **kwargs_likelihood
+        )
         self._num_distribution_draws = int(num_distribution_draws)
         self._kappa_ext_bias = kappa_ext_bias
         self._mst_ifu = mst_ifu
         if kappa_pdf is not None and kappa_bin_edges is not None:
-            self._kappa_dist = PDFSampling(bin_edges=kappa_bin_edges, pdf_array=kappa_pdf)
+            self._kappa_dist = PDFSampling(
+                bin_edges=kappa_bin_edges, pdf_array=kappa_pdf
+            )
             self._draw_kappa = True
         else:
             self._draw_kappa = False
         self._lambda_scaling_property = lambda_scaling_property
         self._lambda_scaling_property_beta = lambda_scaling_property_beta
 
-    def lens_log_likelihood(self, cosmo, kwargs_lens=None, kwargs_kin=None, kwargs_source=None):
+    def lens_log_likelihood(
+        self, cosmo, kwargs_lens=None, kwargs_kin=None, kwargs_source=None
+    ):
         """
         log likelihood of the data of a lens given a model (defined with hyper-parameters) and cosmology
 
@@ -81,15 +113,30 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         # same units
         ddt, dd = self.angular_diameter_distances(cosmo)
         kwargs_source = self._kwargs_init(kwargs_source)
-        z_apparent_m_anchor = kwargs_source.get('z_apparent_m_anchor', 0.1)
+        z_apparent_m_anchor = kwargs_source.get("z_apparent_m_anchor", 0.1)
         delta_lum_dist = self.luminosity_distance_modulus(cosmo, z_apparent_m_anchor)
         # here we effectively change the posteriors of the lens, but rather than changing the instance of the KDE we
         # displace the predicted angular diameter distances in the opposite direction
-        return self.hyper_param_likelihood(ddt, dd, delta_lum_dist, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin,
-                                           kwargs_source=kwargs_source, cosmo=cosmo)
+        return self.hyper_param_likelihood(
+            ddt,
+            dd,
+            delta_lum_dist,
+            kwargs_lens=kwargs_lens,
+            kwargs_kin=kwargs_kin,
+            kwargs_source=kwargs_source,
+            cosmo=cosmo,
+        )
 
-    def hyper_param_likelihood(self, ddt, dd, delta_lum_dist, kwargs_lens=None, kwargs_kin=None, kwargs_source=None,
-                               cosmo=None):
+    def hyper_param_likelihood(
+        self,
+        ddt,
+        dd,
+        delta_lum_dist,
+        kwargs_lens=None,
+        kwargs_kin=None,
+        kwargs_source=None,
+        cosmo=None,
+    ):
         """
         log likelihood of the data of a lens given a model (defined with hyper-parameters) and cosmological distances
 
@@ -106,25 +153,49 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         kwargs_kin = self._kwargs_init(kwargs_kin)
         kwargs_source = self._kwargs_init(kwargs_source)
         kwargs_kin_copy = copy.deepcopy(kwargs_kin)
-        sigma_v_sys_error = kwargs_kin_copy.pop('sigma_v_sys_error', None)
+        sigma_v_sys_error = kwargs_kin_copy.pop("sigma_v_sys_error", None)
 
-        if self.check_dist(kwargs_lens, kwargs_kin, kwargs_source):  # sharp distributions
-            return self.log_likelihood_single(ddt, dd, delta_lum_dist, kwargs_lens, kwargs_kin_copy, kwargs_source,
-                                              sigma_v_sys_error=sigma_v_sys_error)
+        if self.check_dist(
+            kwargs_lens, kwargs_kin, kwargs_source
+        ):  # sharp distributions
+            return self.log_likelihood_single(
+                ddt,
+                dd,
+                delta_lum_dist,
+                kwargs_lens,
+                kwargs_kin_copy,
+                kwargs_source,
+                sigma_v_sys_error=sigma_v_sys_error,
+            )
         else:
             likelihood = 0
             for i in range(self._num_distribution_draws):
-                logl = self.log_likelihood_single(ddt, dd, delta_lum_dist, kwargs_lens, kwargs_kin_copy, kwargs_source,
-                                                  sigma_v_sys_error=sigma_v_sys_error)
+                logl = self.log_likelihood_single(
+                    ddt,
+                    dd,
+                    delta_lum_dist,
+                    kwargs_lens,
+                    kwargs_kin_copy,
+                    kwargs_source,
+                    sigma_v_sys_error=sigma_v_sys_error,
+                )
                 exp_logl = np.exp(logl)
                 if np.isfinite(exp_logl) and exp_logl > 0:
                     likelihood += exp_logl
             if likelihood <= 0:
                 return -np.inf
-            return np.log(likelihood/self._num_distribution_draws)
+            return np.log(likelihood / self._num_distribution_draws)
 
-    def log_likelihood_single(self, ddt, dd, delta_lum_dist, kwargs_lens, kwargs_kin, kwargs_source,
-                              sigma_v_sys_error=None):
+    def log_likelihood_single(
+        self,
+        ddt,
+        dd,
+        delta_lum_dist,
+        kwargs_lens,
+        kwargs_kin,
+        kwargs_source,
+        sigma_v_sys_error=None,
+    ):
         """
         log likelihood of the data of a lens given a specific model (as a draw from hyper-parameters) and cosmological
         distances
@@ -142,13 +213,24 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         lambda_mst, kappa_ext, gamma_ppn = self.draw_lens(**kwargs_lens)
         # draw intrinsic source magnitude
         mag_source = self.draw_source(lum_dist=delta_lum_dist, **kwargs_source)
-        ddt_, dd_, mag_source_ = self.displace_prediction(ddt, dd, gamma_ppn=gamma_ppn, lambda_mst=lambda_mst,
-                                                          kappa_ext=kappa_ext, mag_source=mag_source)
+        ddt_, dd_, mag_source_ = self.displace_prediction(
+            ddt,
+            dd,
+            gamma_ppn=gamma_ppn,
+            lambda_mst=lambda_mst,
+            kappa_ext=kappa_ext,
+            mag_source=mag_source,
+        )
         aniso_param_array = self.draw_anisotropy(**kwargs_kin)
         aniso_scaling = self.ani_scaling(aniso_param_array)
 
-        lnlikelihood = self.log_likelihood(ddt_, dd_, aniso_scaling=aniso_scaling, sigma_v_sys_error=sigma_v_sys_error,
-                                           mu_intrinsic=mag_source_)
+        lnlikelihood = self.log_likelihood(
+            ddt_,
+            dd_,
+            aniso_scaling=aniso_scaling,
+            sigma_v_sys_error=sigma_v_sys_error,
+            mu_intrinsic=mag_source_,
+        )
         return np.nan_to_num(lnlikelihood)
 
     def angular_diameter_distances(self, cosmo):
@@ -160,9 +242,13 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         """
         dd = cosmo.angular_diameter_distance(z=self._z_lens).value
         ds = cosmo.angular_diameter_distance(z=self._z_source).value
-        dds = cosmo.angular_diameter_distance_z1z2(z1=self._z_lens, z2=self._z_source).value
-        ddt = (1. + self._z_lens) * dd * ds / dds
-        return np.maximum(np.nan_to_num(ddt), 0.00001), np.maximum(np.nan_to_num(dd), 0.00001)
+        dds = cosmo.angular_diameter_distance_z1z2(
+            z1=self._z_lens, z2=self._z_source
+        ).value
+        ddt = (1.0 + self._z_lens) * dd * ds / dds
+        return np.maximum(np.nan_to_num(ddt), 0.00001), np.maximum(
+            np.nan_to_num(dd), 0.00001
+        )
 
     def luminosity_distance_modulus(self, cosmo, z_apparent_m_anchor):
         """
@@ -173,13 +259,21 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         :param z_apparent_m_anchor: redshift of pivot/anchor at which the apparent SNe brightness is defined relative to
         :return: lum_dist(z_source) - lum_dist(z_pivot)
         """
-        angular_diameter_distances = np.maximum(np.nan_to_num(cosmo.angular_diameter_distance(self._z_source).value),
-                                                0.00001)
-        lum_dists = (5 * np.log10((1 + self._z_source) * (1 + self._z_source) * angular_diameter_distances))
+        angular_diameter_distances = np.maximum(
+            np.nan_to_num(cosmo.angular_diameter_distance(self._z_source).value),
+            0.00001,
+        )
+        lum_dists = 5 * np.log10(
+            (1 + self._z_source) * (1 + self._z_source) * angular_diameter_distances
+        )
 
         z_anchor = z_apparent_m_anchor
-        ang_dist_anchor = np.maximum(np.nan_to_num(cosmo.angular_diameter_distance(z_anchor).value), 0.00001)
-        lum_dist_anchor = (5 * np.log10((1 + z_anchor) * (1 + z_anchor) * ang_dist_anchor))
+        ang_dist_anchor = np.maximum(
+            np.nan_to_num(cosmo.angular_diameter_distance(z_anchor).value), 0.00001
+        )
+        lum_dist_anchor = 5 * np.log10(
+            (1 + z_anchor) * (1 + z_anchor) * ang_dist_anchor
+        )
         delta_lum_dist = lum_dists - lum_dist_anchor
         return delta_lum_dist
 
@@ -193,19 +287,34 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         :param kwargs_source: source brightness hyper-parameter keywords
         :return: bool, True if delta function, else False
         """
-        lambda_mst_sigma = kwargs_lens.get('lambda_mst_sigma', 0)  # scatter in MST
-        kappa_ext_sigma = kwargs_lens.get('kappa_ext_sigma', 0)
-        a_ani_sigma = kwargs_kin.get('a_ani_sigma', 0)
-        beta_inf_sigma = kwargs_kin.get('beta_inf_sigma', 0)
-        sne_sigma = kwargs_source.get('sigma_sne', 0)
-        if a_ani_sigma == 0 and lambda_mst_sigma == 0 and kappa_ext_sigma == 0 and beta_inf_sigma == 0 \
-           and sne_sigma == 0:
+        lambda_mst_sigma = kwargs_lens.get("lambda_mst_sigma", 0)  # scatter in MST
+        kappa_ext_sigma = kwargs_lens.get("kappa_ext_sigma", 0)
+        a_ani_sigma = kwargs_kin.get("a_ani_sigma", 0)
+        beta_inf_sigma = kwargs_kin.get("beta_inf_sigma", 0)
+        sne_sigma = kwargs_source.get("sigma_sne", 0)
+        if (
+            a_ani_sigma == 0
+            and lambda_mst_sigma == 0
+            and kappa_ext_sigma == 0
+            and beta_inf_sigma == 0
+            and sne_sigma == 0
+        ):
             if self._draw_kappa is False:
                 return True
         return False
 
-    def draw_lens(self, lambda_mst=1, lambda_mst_sigma=0, kappa_ext=0, kappa_ext_sigma=0, gamma_ppn=1, lambda_ifu=1,
-                  lambda_ifu_sigma=0, alpha_lambda=0, beta_lambda=0):
+    def draw_lens(
+        self,
+        lambda_mst=1,
+        lambda_mst_sigma=0,
+        kappa_ext=0,
+        kappa_ext_sigma=0,
+        gamma_ppn=1,
+        lambda_ifu=1,
+        lambda_ifu_sigma=0,
+        alpha_lambda=0,
+        beta_lambda=0,
+    ):
         """
         draws a realization of a specific model from the hyper-parameter distribution
 
@@ -223,12 +332,18 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         :return: draw from the distributions
         """
         if self._mst_ifu is True:
-            lambda_lens = lambda_ifu + alpha_lambda * self._lambda_scaling_property \
-                          + beta_lambda * self._lambda_scaling_property_beta
+            lambda_lens = (
+                lambda_ifu
+                + alpha_lambda * self._lambda_scaling_property
+                + beta_lambda * self._lambda_scaling_property_beta
+            )
             lambda_mst_draw = np.random.normal(lambda_lens, lambda_ifu_sigma)
         else:
-            lambda_lens = lambda_mst + alpha_lambda * self._lambda_scaling_property \
-                          + beta_lambda * self._lambda_scaling_property_beta
+            lambda_lens = (
+                lambda_mst
+                + alpha_lambda * self._lambda_scaling_property
+                + beta_lambda * self._lambda_scaling_property_beta
+            )
             lambda_mst_draw = np.random.normal(lambda_lens, lambda_mst_sigma)
         if self._draw_kappa is True:
             kappa_ext_draw = self._kappa_dist.draw_one
@@ -267,26 +382,31 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         :return: sigma_v_measurement, cov_error_measurement, sigma_v_predict_mean, cov_error_predict
         """
         # if no kinematics is provided, return None's
-        if self.likelihood_type not in ['DdtHistKin', 'IFUKinCov', 'DdtGaussKin']:
+        if self.likelihood_type not in ["DdtHistKin", "IFUKinCov", "DdtGaussKin"]:
             return None, None, None, None
         if kwargs_lens is None:
             kwargs_lens = {}
         if kwargs_kin is None:
             kwargs_kin = {}
         kwargs_kin_copy = copy.deepcopy(kwargs_kin)
-        sigma_v_sys_error = kwargs_kin_copy.pop('sigma_v_sys_error', None)
+        sigma_v_sys_error = kwargs_kin_copy.pop("sigma_v_sys_error", None)
         ddt, dd = self.angular_diameter_distances(cosmo)
-        sigma_v_measurement, cov_error_measurement = self.sigma_v_measurement(sigma_v_sys_error=sigma_v_sys_error)
+        sigma_v_measurement, cov_error_measurement = self.sigma_v_measurement(
+            sigma_v_sys_error=sigma_v_sys_error
+        )
         sigma_v_predict_list = []
         sigma_v_predict_mean = np.zeros_like(sigma_v_measurement)
         cov_error_predict = np.zeros_like(cov_error_measurement)
         for i in range(self._num_distribution_draws):
             lambda_mst, kappa_ext, gamma_ppn = self.draw_lens(**kwargs_lens)
-            ddt_, dd_, _ = self.displace_prediction(ddt, dd, gamma_ppn=gamma_ppn, lambda_mst=lambda_mst,
-                                                    kappa_ext=kappa_ext)
+            ddt_, dd_, _ = self.displace_prediction(
+                ddt, dd, gamma_ppn=gamma_ppn, lambda_mst=lambda_mst, kappa_ext=kappa_ext
+            )
             aniso_param_array = self.draw_anisotropy(**kwargs_kin_copy)
             aniso_scaling = self.ani_scaling(aniso_param_array)
-            sigma_v_predict_i, cov_error_predict_i = self.sigma_v_prediction(ddt_, dd_, aniso_scaling=aniso_scaling)
+            sigma_v_predict_i, cov_error_predict_i = self.sigma_v_prediction(
+                ddt_, dd_, aniso_scaling=aniso_scaling
+            )
             sigma_v_predict_mean += sigma_v_predict_i
             cov_error_predict += cov_error_predict_i
             sigma_v_predict_list.append(sigma_v_predict_i)
@@ -298,7 +418,12 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         cov_error_predict += np.cov(sigma_v_predict_list.T)
         # sigma_v_mean_std = np.std(sigma_v_predict_list, axis=0)
         # cov_error_predict += np.outer(sigma_v_mean_std, sigma_v_mean_std)
-        return sigma_v_measurement, cov_error_measurement, sigma_v_predict_mean, cov_error_predict
+        return (
+            sigma_v_measurement,
+            cov_error_measurement,
+            sigma_v_predict_mean,
+            cov_error_predict,
+        )
 
     def ddt_dd_model_prediction(self, cosmo, kwargs_lens=None):
         """
@@ -315,11 +440,17 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         dd_draws = []
         for i in range(self._num_distribution_draws):
             lambda_mst, kappa_ext, gamma_ppn = self.draw_lens(**kwargs_lens)
-            ddt_, dd_, _ = self.displace_prediction(ddt, dd, gamma_ppn=gamma_ppn, lambda_mst=lambda_mst,
-                                                    kappa_ext=kappa_ext)
+            ddt_, dd_, _ = self.displace_prediction(
+                ddt, dd, gamma_ppn=gamma_ppn, lambda_mst=lambda_mst, kappa_ext=kappa_ext
+            )
             ddt_draws.append(ddt_)
             dd_draws.append(dd_)
-        return np.mean(ddt_draws), np.std(ddt_draws), np.mean(dd_draws), np.std(dd_draws)
+        return (
+            np.mean(ddt_draws),
+            np.std(ddt_draws),
+            np.mean(dd_draws),
+            np.std(dd_draws),
+        )
 
     @staticmethod
     def _kwargs_init(kwargs=None):

--- a/hierarc/Likelihood/hierarchy_likelihood.py
+++ b/hierarc/Likelihood/hierarchy_likelihood.py
@@ -7,9 +7,8 @@ import copy
 
 
 class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScalingIFU):
-    """
-    master class containing the likelihood definitions of different analysis for s single lens
-    """
+    """Master class containing the likelihood definitions of different analysis for s
+    single lens."""
 
     def __init__(
         self,
@@ -98,8 +97,8 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
     def lens_log_likelihood(
         self, cosmo, kwargs_lens=None, kwargs_kin=None, kwargs_source=None
     ):
-        """
-        log likelihood of the data of a lens given a model (defined with hyper-parameters) and cosmology
+        """Log likelihood of the data of a lens given a model (defined with hyper-
+        parameters) and cosmology.
 
         :param cosmo: astropy.cosmology instance
         :param kwargs_lens: keywords of the hyper parameters of the lens model
@@ -137,8 +136,8 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         kwargs_source=None,
         cosmo=None,
     ):
-        """
-        log likelihood of the data of a lens given a model (defined with hyper-parameters) and cosmological distances
+        """Log likelihood of the data of a lens given a model (defined with hyper-
+        parameters) and cosmological distances.
 
         :param ddt: time-delay distance
         :param dd: angular diameter distance to the deflector
@@ -147,7 +146,8 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         :param kwargs_kin: keyword arguments of the kinematic model hyper parameters
         :param kwargs_source: keyword argument of the source model (such as SNe)
         :param cosmo: astropy.cosmology instance
-        :return: log likelihood given the single lens analysis for the given hyper parameter
+        :return: log likelihood given the single lens analysis for the given hyper
+            parameter
         """
         kwargs_lens = self._kwargs_init(kwargs_lens)
         kwargs_kin = self._kwargs_init(kwargs_kin)
@@ -196,9 +196,8 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         kwargs_source,
         sigma_v_sys_error=None,
     ):
-        """
-        log likelihood of the data of a lens given a specific model (as a draw from hyper-parameters) and cosmological
-        distances
+        """Log likelihood of the data of a lens given a specific model (as a draw from
+        hyper-parameters) and cosmological distances.
 
         :param ddt: time-delay distance
         :param dd: angular diameter distance to the deflector
@@ -206,9 +205,10 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         :param kwargs_lens: keywords of the hyper parameters of the lens model
         :param kwargs_kin: keyword arguments of the kinematic model hyper parameters
         :param kwargs_source: keyword arguments of source brightness
-        :param sigma_v_sys_error: unaccounted uncertainty in the velocity dispersion measurement
-        :return: log likelihood given the single lens analysis for a single (random) realization of the hyper parameter
-         distribution
+        :param sigma_v_sys_error: unaccounted uncertainty in the velocity dispersion
+            measurement
+        :return: log likelihood given the single lens analysis for a single (random)
+            realization of the hyper parameter distribution
         """
         lambda_mst, kappa_ext, gamma_ppn = self.draw_lens(**kwargs_lens)
         # draw intrinsic source magnitude
@@ -234,8 +234,7 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         return np.nan_to_num(lnlikelihood)
 
     def angular_diameter_distances(self, cosmo):
-        """
-        time-delay distance Ddt, angular diameter distance to the lens (dd)
+        """Time-delay distance Ddt, angular diameter distance to the lens (dd)
 
         :param cosmo: astropy.cosmology instance (or equivalent with interpolation)
         :return: ddt, dd, ds in units physical Mpc
@@ -251,9 +250,9 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         )
 
     def luminosity_distance_modulus(self, cosmo, z_apparent_m_anchor):
-        """
-        the difference in luminosity distance between a pivot redshift (z_apparent_m_anchor) and the source redshift
-        (effectively the ratio as this is the magnitude transform)
+        """The difference in luminosity distance between a pivot redshift
+        (z_apparent_m_anchor) and the source redshift (effectively the ratio as this is
+        the magnitude transform)
 
         :param cosmo: astropy.cosmology instance (or equivalent with interpolation)
         :param z_apparent_m_anchor: redshift of pivot/anchor at which the apparent SNe brightness is defined relative to
@@ -278,9 +277,8 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         return delta_lum_dist
 
     def check_dist(self, kwargs_lens, kwargs_kin, kwargs_source):
-        """
-        checks if the provided keyword arguments describe a distribution function of hyper parameters or are single
-        values
+        """Checks if the provided keyword arguments describe a distribution function of
+        hyper parameters or are single values.
 
         :param kwargs_lens: lens model hyper-parameter keywords
         :param kwargs_kin: kinematic model hyper-parameter keywords
@@ -315,20 +313,22 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         alpha_lambda=0,
         beta_lambda=0,
     ):
-        """
-        draws a realization of a specific model from the hyper-parameter distribution
+        """Draws a realization of a specific model from the hyper-parameter
+        distribution.
 
         :param lambda_mst: MST transform
         :param lambda_mst_sigma: spread in the distribution
         :param kappa_ext: external convergence mean in distribution
         :param kappa_ext_sigma: spread in the distribution
         :param gamma_ppn: Post-Newtonian parameter
-        :param lambda_ifu: secondary lambda_mst parameter for subset of lenses specified for
-        :param lambda_ifu_sigma: secondary lambda_mst_sigma parameter for subset of lenses specified for
-        :param alpha_lambda: float, linear slope of the lambda_int scaling relation with lens quantity
-         self._lambda_scaling_property
-        :param beta_lambda: float, a second linear slope of the lambda_int scaling relation with lens quantity
-         self._lambda_scaling_property_beta
+        :param lambda_ifu: secondary lambda_mst parameter for subset of lenses specified
+            for
+        :param lambda_ifu_sigma: secondary lambda_mst_sigma parameter for subset of
+            lenses specified for
+        :param alpha_lambda: float, linear slope of the lambda_int scaling relation with
+            lens quantity self._lambda_scaling_property
+        :param beta_lambda: float, a second linear slope of the lambda_int scaling
+            relation with lens quantity self._lambda_scaling_property_beta
         :return: draw from the distributions
         """
         if self._mst_ifu is True:
@@ -355,13 +355,14 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
 
     @staticmethod
     def draw_source(mu_sne=1, sigma_sne=0, lum_dist=0, **kwargs):
-        """
-        draws a source magnitude from a distribution specified by population parameters
+        """Draws a source magnitude from a distribution specified by population
+        parameters.
 
         :param mu_sne: mean magnitude of SNe
-        :param sigma_sne: std of magnitude distribution of SNe relative to the mean magnitude
-        :param lum_dist: luminosity distance
-         (astronomical magnitude scaling of defined brightness to the source redshift)
+        :param sigma_sne: std of magnitude distribution of SNe relative to the mean
+            magnitude
+        :param lum_dist: luminosity distance (astronomical magnitude scaling of defined
+            brightness to the source redshift)
         :return: realization of source amplitude given distribution
         """
         # draw apparent magnitude at pivot luminosity distance (z=0.1)
@@ -372,14 +373,14 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         return mag_source
 
     def sigma_v_measured_vs_predict(self, cosmo, kwargs_lens=None, kwargs_kin=None):
-        """
-        mean and error covariance of velocity dispersion measurement
-        mean and error covariance of velocity dispersion predictions
+        """Mean and error covariance of velocity dispersion measurement mean and error
+        covariance of velocity dispersion predictions.
 
         :param cosmo: astropy.cosmology instance
         :param kwargs_lens: keywords of the hyper parameters of the lens model
         :param kwargs_kin: keyword arguments of the kinematic model hyper parameters
-        :return: sigma_v_measurement, cov_error_measurement, sigma_v_predict_mean, cov_error_predict
+        :return: sigma_v_measurement, cov_error_measurement, sigma_v_predict_mean,
+            cov_error_predict
         """
         # if no kinematics is provided, return None's
         if self.likelihood_type not in ["DdtHistKin", "IFUKinCov", "DdtGaussKin"]:
@@ -426,8 +427,8 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, AnisotropyScali
         )
 
     def ddt_dd_model_prediction(self, cosmo, kwargs_lens=None):
-        """
-        predicts the model uncertainty corrected ddt prediction of the applied model (e.g. power-law)
+        """Predicts the model uncertainty corrected ddt prediction of the applied model
+        (e.g. power-law)
 
         :param cosmo: astropy.cosmology instance
         :param kwargs_lens: keywords of the hyper parameters of the lens model

--- a/hierarc/Likelihood/lens_sample_likelihood.py
+++ b/hierarc/Likelihood/lens_sample_likelihood.py
@@ -5,10 +5,9 @@ from hierarc.Likelihood.LensLikelihood.double_source_plane import DSPLikelihood
 
 
 class LensSampleLikelihood(object):
-    """
-    class to evaluate the likelihood of a cosmology given a sample of angular diameter posteriors
-    Currently this class does not include possible covariances between the lens samples
-    """
+    """Class to evaluate the likelihood of a cosmology given a sample of angular
+    diameter posteriors Currently this class does not include possible covariances
+    between the lens samples."""
 
     def __init__(self, kwargs_lens_list, normalized=False):
         """
@@ -52,8 +51,7 @@ class LensSampleLikelihood(object):
         return log_likelihood
 
     def num_data(self):
-        """
-        number of data points across the lens sample
+        """Number of data points across the lens sample.
 
         :return: integer
         """

--- a/hierarc/Likelihood/lens_sample_likelihood.py
+++ b/hierarc/Likelihood/lens_sample_likelihood.py
@@ -9,6 +9,7 @@ class LensSampleLikelihood(object):
     class to evaluate the likelihood of a cosmology given a sample of angular diameter posteriors
     Currently this class does not include possible covariances between the lens samples
     """
+
     def __init__(self, kwargs_lens_list, normalized=False):
         """
 
@@ -18,14 +19,20 @@ class LensSampleLikelihood(object):
         """
         self._lens_list = []
         for kwargs_lens in kwargs_lens_list:
-            if kwargs_lens['likelihood_type'] == 'DSPL':
+            if kwargs_lens["likelihood_type"] == "DSPL":
                 _kwargs_lens = copy.deepcopy(kwargs_lens)
-                _kwargs_lens.pop('likelihood_type')
-                self._lens_list.append(DSPLikelihood(normalized=normalized, **_kwargs_lens))
+                _kwargs_lens.pop("likelihood_type")
+                self._lens_list.append(
+                    DSPLikelihood(normalized=normalized, **_kwargs_lens)
+                )
             else:
-                self._lens_list.append(LensLikelihood(normalized=normalized, **kwargs_lens))
+                self._lens_list.append(
+                    LensLikelihood(normalized=normalized, **kwargs_lens)
+                )
 
-    def log_likelihood(self, cosmo, kwargs_lens=None, kwargs_kin=None, kwargs_source=None):
+    def log_likelihood(
+        self, cosmo, kwargs_lens=None, kwargs_kin=None, kwargs_source=None
+    ):
         """
 
         :param cosmo: astropy.cosmology instance
@@ -36,8 +43,12 @@ class LensSampleLikelihood(object):
         """
         log_likelihood = 0
         for lens in self._lens_list:
-            log_likelihood += lens.lens_log_likelihood(cosmo=cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin,
-                                                       kwargs_source=kwargs_source)
+            log_likelihood += lens.lens_log_likelihood(
+                cosmo=cosmo,
+                kwargs_lens=kwargs_lens,
+                kwargs_kin=kwargs_kin,
+                kwargs_source=kwargs_source,
+            )
         return log_likelihood
 
     def num_data(self):

--- a/hierarc/Likelihood/transformed_cosmography.py
+++ b/hierarc/Likelihood/transformed_cosmography.py
@@ -1,4 +1,4 @@
-__author__ = 'sibirrer'
+__author__ = "sibirrer"
 import numpy as np
 
 
@@ -17,7 +17,9 @@ class TransformedCosmography(object):
         self._z_lens = z_lens
         self._z_source = z_source
 
-    def displace_prediction(self, ddt, dd, gamma_ppn=1, lambda_mst=1, kappa_ext=0, mag_source=0):
+    def displace_prediction(
+        self, ddt, dd, gamma_ppn=1, lambda_mst=1, kappa_ext=0, mag_source=0
+    ):
         """
         here we effectively change the posteriors of the lens, but rather than changing the instance of the KDE we
         displace the predicted angular diameter distances in the opposite direction
@@ -34,9 +36,10 @@ class TransformedCosmography(object):
         :returns: ddt, dd, mag_source
         """
         ddt_, dd_ = self._displace_ppn(ddt, dd, gamma_ppn=gamma_ppn)
-        #TODO scale source with ds, make sure definition is either linear or magnitudes (log) consistently
-        ddt_, dd_, mag_source_ = self._displace_lambda_mst(ddt_, dd_, lambda_mst=lambda_mst, kappa_ext=kappa_ext,
-                                                           mag_source=mag_source)
+        # TODO scale source with ds, make sure definition is either linear or magnitudes (log) consistently
+        ddt_, dd_, mag_source_ = self._displace_lambda_mst(
+            ddt_, dd_, lambda_mst=lambda_mst, kappa_ext=kappa_ext, mag_source=mag_source
+        )
         return ddt_, dd_, mag_source_
 
     @staticmethod
@@ -50,7 +53,7 @@ class TransformedCosmography(object):
         :param gamma_ppn: post-newtonian gravity parameter (=1 is GR)
         :return: ddt_, dd_
         """
-        dd_ = dd * (1 + gamma_ppn) / 2.
+        dd_ = dd * (1 + gamma_ppn) / 2.0
         return ddt, dd_
 
     @staticmethod
@@ -66,7 +69,7 @@ class TransformedCosmography(object):
         :param kappa_ext: external convergence to be added on top of the D_dt posterior
         :return: ddt_, dd_
         """
-        ddt_ = ddt * (1. - kappa_ext)
+        ddt_ = ddt * (1.0 - kappa_ext)
         return ddt_, dd
 
     @staticmethod
@@ -87,12 +90,20 @@ class TransformedCosmography(object):
         :return: ddt_, dd_, mag_source
         """
         lambda_tot = lambda_mst * (1 - kappa_ext)  # combine internal and external MST
-        lambda_tot = np.maximum(lambda_tot, 0.0001)  # lambda can not get negative and zero is leading to infinite magnitudes
-        ddt_ = ddt * lambda_tot  # the actual posteriors needed to be corrected by Ddt_true = Ddt_mst / (1-kappa_ext)
+        lambda_tot = np.maximum(
+            lambda_tot, 0.0001
+        )  # lambda can not get negative and zero is leading to infinite magnitudes
+        ddt_ = (
+            ddt * lambda_tot
+        )  # the actual posteriors needed to be corrected by Ddt_true = Ddt_mst / (1-kappa_ext)
         # this line can be changed in case the physical 3-d approximation of the chosen profile does scale differently with the kinematics
         sigma_v2_scaling = lambda_mst
-        dd_ = dd * sigma_v2_scaling / lambda_mst  # the kinematics constrain Dd/Dds and thus the constraints on Dd is not affected by lambda
+        dd_ = (
+            dd * sigma_v2_scaling / lambda_mst
+        )  # the kinematics constrain Dd/Dds and thus the constraints on Dd is not affected by lambda
 
         # amp_source_ = amp_source / lambda_tot ** 2  # inverse MST transform of magnification
-        mag_source_ = mag_source + 5 * np.log10(lambda_tot)  # inverse MST transform of magnification in magnitude
+        mag_source_ = mag_source + 5 * np.log10(
+            lambda_tot
+        )  # inverse MST transform of magnification in magnitude
         return ddt_, dd_, mag_source_

--- a/hierarc/Likelihood/transformed_cosmography.py
+++ b/hierarc/Likelihood/transformed_cosmography.py
@@ -3,10 +3,8 @@ import numpy as np
 
 
 class TransformedCosmography(object):
-    """
-    class to manage hierarchical hyper-parameter that impact the cosmographic posterior interpretation of individual
-    lenses.
-    """
+    """Class to manage hierarchical hyper-parameter that impact the cosmographic
+    posterior interpretation of individual lenses."""
 
     def __init__(self, z_lens, z_source):
         """
@@ -20,19 +18,20 @@ class TransformedCosmography(object):
     def displace_prediction(
         self, ddt, dd, gamma_ppn=1, lambda_mst=1, kappa_ext=0, mag_source=0
     ):
-        """
-        here we effectively change the posteriors of the lens, but rather than changing the instance of the KDE we
-        displace the predicted angular diameter distances in the opposite direction
-        The displacements form different effects are multiplicative and thus invariant under the order those
-        displacements are applied.
+        """Here we effectively change the posteriors of the lens, but rather than
+        changing the instance of the KDE we displace the predicted angular diameter
+        distances in the opposite direction The displacements form different effects are
+        multiplicative and thus invariant under the order those displacements are
+        applied.
 
         :param ddt: time-delay distance
         :param dd: angular diameter distance to the deflector
         :param lambda_mst: overall global mass-sheet transform applied on the sample,
-         lambda_mst=1 corresponds to the input model
+            lambda_mst=1 corresponds to the input model
         :param gamma_ppn: post-newtonian gravity parameter (=1 is GR)
         :param kappa_ext: external convergence to be added on top of the D_dt posterior
-        :param mag_source: source magnitude (attention, log scale, thus transform needs to be changed!)
+        :param mag_source: source magnitude (attention, log scale, thus transform needs
+            to be changed!)
         :returns: ddt, dd, mag_source
         """
         ddt_, dd_ = self._displace_ppn(ddt, dd, gamma_ppn=gamma_ppn)
@@ -44,9 +43,9 @@ class TransformedCosmography(object):
 
     @staticmethod
     def _displace_ppn(ddt, dd, gamma_ppn=1):
-        """
-        post-Newtonian parameter sampling. The deflection terms remain the same as those are measured by lensing.
-        The dynamical term changes and affects the kinematic prediction and thus dd
+        """Post-Newtonian parameter sampling. The deflection terms remain the same as
+        those are measured by lensing. The dynamical term changes and affects the
+        kinematic prediction and thus dd.
 
         :param ddt: time-delay distance
         :param dd: angular diameter distance to the deflector
@@ -58,11 +57,11 @@ class TransformedCosmography(object):
 
     @staticmethod
     def _displace_kappa_ext(ddt, dd, kappa_ext=0):
-        """
-        assumes an additional mass-sheet of kappa_ext is present at the lens LOS (effectively mimicing an overall
-        selection bias in the lenses that is not visible in the individual LOS analyses of the lenses.
-        This is speculative and should only be considered if there are specific reasons why the current LOS analysis
-        is insufficient.
+        """Assumes an additional mass-sheet of kappa_ext is present at the lens LOS
+        (effectively mimicing an overall selection bias in the lenses that is not
+        visible in the individual LOS analyses of the lenses. This is speculative and
+        should only be considered if there are specific reasons why the current LOS
+        analysis is insufficient.
 
         :param ddt: time-delay distance
         :param dd: angular diameter distance to the deflector
@@ -74,10 +73,12 @@ class TransformedCosmography(object):
 
     @staticmethod
     def _displace_lambda_mst(ddt, dd, lambda_mst=1, kappa_ext=0, mag_source=0):
-        """
-        approximate internal mass-sheet transform on top of the assumed profiles inferred in the analysis of the
-        individual lenses. The effect is to first order the same as for a pure mass sheet as a kappa_ext term.
-        However the change here affects the 3-dimensional mass profile and thus the kinematics predictions is affected.
+        """Approximate internal mass-sheet transform on top of the assumed profiles
+        inferred in the analysis of the individual lenses. The effect is to first order
+        the same as for a pure mass sheet as a kappa_ext term. However the change here
+        affects the 3-dimensional mass profile and thus the kinematics predictions is
+        affected.
+
         We showed that for a set of profiles, the kinematics of a 3-d approximate mass sheet can still be very well
         approximated as d sigma_v_lambda**2 /d lambda = lambda * sigma_v0
 

--- a/hierarc/Sampling/ParamManager/cosmo_param.py
+++ b/hierarc/Sampling/ParamManager/cosmo_param.py
@@ -2,9 +2,7 @@ from astropy.cosmology import FlatLambdaCDM, FlatwCDM, LambdaCDM, w0waCDM
 
 
 class CosmoParam(object):
-    """
-    manages the cosmological parameters in the sampling
-    """
+    """Manages the cosmological parameters in the sampling."""
 
     def __init__(self, cosmology, ppn_sampling=False, kwargs_fixed=None):
         """

--- a/hierarc/Sampling/ParamManager/cosmo_param.py
+++ b/hierarc/Sampling/ParamManager/cosmo_param.py
@@ -5,6 +5,7 @@ class CosmoParam(object):
     """
     manages the cosmological parameters in the sampling
     """
+
     def __init__(self, cosmology, ppn_sampling=False, kwargs_fixed=None):
         """
 
@@ -20,7 +21,9 @@ class CosmoParam(object):
         self._supported_cosmologies = ["FLCDM", "FwCDM", "w0waCDM", "oLCDM", "NONE"]
         if cosmology not in self._supported_cosmologies:
             raise ValueError(
-                'cosmology %s not supported!. Please chose among %s ' % (cosmology, self._supported_cosmologies))
+                "cosmology %s not supported!. Please chose among %s "
+                % (cosmology, self._supported_cosmologies)
+            )
 
     def param_list(self, latex_style=False):
         """
@@ -30,46 +33,46 @@ class CosmoParam(object):
         """
         list = []
         if self._cosmology not in ["NONE"]:
-            if 'h0' not in self._kwargs_fixed:
+            if "h0" not in self._kwargs_fixed:
                 if latex_style is True:
-                    list.append(r'$H_0$')
+                    list.append(r"$H_0$")
                 else:
-                    list.append('h0')
+                    list.append("h0")
             if self._cosmology in ["FLCDM", "FwCDM", "w0waCDM", "oLCDM"]:
-                if 'om' not in self._kwargs_fixed:
+                if "om" not in self._kwargs_fixed:
                     if latex_style is True:
-                        list.append(r'$\Omega_{\rm m}$')
+                        list.append(r"$\Omega_{\rm m}$")
                     else:
-                        list.append('om')
+                        list.append("om")
             if self._cosmology in ["FwCDM"]:
-                if 'w' not in self._kwargs_fixed:
+                if "w" not in self._kwargs_fixed:
                     if latex_style is True:
-                        list.append(r'$w$')
+                        list.append(r"$w$")
                     else:
-                        list.append('w')
+                        list.append("w")
             if self._cosmology in ["w0waCDM"]:
-                if 'w0' not in self._kwargs_fixed:
+                if "w0" not in self._kwargs_fixed:
                     if latex_style is True:
-                        list.append(r'$w_0$')
+                        list.append(r"$w_0$")
                     else:
-                        list.append('w0')
-                if 'wa' not in self._kwargs_fixed:
+                        list.append("w0")
+                if "wa" not in self._kwargs_fixed:
                     if latex_style is True:
-                        list.append(r'$w_{\rm a}$')
+                        list.append(r"$w_{\rm a}$")
                     else:
-                        list.append('wa')
+                        list.append("wa")
             if self._cosmology in ["oLCDM"]:
-                if 'ok' not in self._kwargs_fixed:
+                if "ok" not in self._kwargs_fixed:
                     if latex_style is True:
-                        list.append(r'$\Omega_{\rm k}$')
+                        list.append(r"$\Omega_{\rm k}$")
                     else:
-                        list.append('ok')
+                        list.append("ok")
         if self._ppn_sampling is True:
-            if 'gamma_ppn' not in self._kwargs_fixed:
+            if "gamma_ppn" not in self._kwargs_fixed:
                 if latex_style is True:
-                    list.append(r'$\gamma_{\rm ppn}$')
+                    list.append(r"$\gamma_{\rm ppn}$")
                 else:
-                    list.append('gamma_ppn')
+                    list.append("gamma_ppn")
         return list
 
     def args2kwargs(self, args, i=0):
@@ -80,45 +83,45 @@ class CosmoParam(object):
         """
         kwargs = {}
         if self._cosmology not in ["NONE"]:
-            if 'h0' in self._kwargs_fixed:
-                kwargs['h0'] = self._kwargs_fixed['h0']
+            if "h0" in self._kwargs_fixed:
+                kwargs["h0"] = self._kwargs_fixed["h0"]
             else:
-                kwargs['h0'] = args[i]
+                kwargs["h0"] = args[i]
                 i += 1
             if self._cosmology in ["FLCDM", "FwCDM", "w0waCDM", "oLCDM"]:
-                if 'om' in self._kwargs_fixed:
-                    kwargs['om'] = self._kwargs_fixed['om']
+                if "om" in self._kwargs_fixed:
+                    kwargs["om"] = self._kwargs_fixed["om"]
                 else:
-                    kwargs['om'] = args[i]
+                    kwargs["om"] = args[i]
                     i += 1
             if self._cosmology in ["FwCDM"]:
-                if 'w' in self._kwargs_fixed:
-                    kwargs['w'] = self._kwargs_fixed['w']
+                if "w" in self._kwargs_fixed:
+                    kwargs["w"] = self._kwargs_fixed["w"]
                 else:
-                    kwargs['w'] = args[i]
+                    kwargs["w"] = args[i]
                     i += 1
             if self._cosmology in ["w0waCDM"]:
-                if 'w0' in self._kwargs_fixed:
-                    kwargs['w0'] = self._kwargs_fixed['w0']
+                if "w0" in self._kwargs_fixed:
+                    kwargs["w0"] = self._kwargs_fixed["w0"]
                 else:
-                    kwargs['w0'] = args[i]
+                    kwargs["w0"] = args[i]
                     i += 1
-                if 'wa' in self._kwargs_fixed:
-                    kwargs['wa'] = self._kwargs_fixed['wa']
+                if "wa" in self._kwargs_fixed:
+                    kwargs["wa"] = self._kwargs_fixed["wa"]
                 else:
-                    kwargs['wa'] = args[i]
+                    kwargs["wa"] = args[i]
                     i += 1
             if self._cosmology in ["oLCDM"]:
-                if 'ok' in self._kwargs_fixed:
-                    kwargs['ok'] = self._kwargs_fixed['ok']
+                if "ok" in self._kwargs_fixed:
+                    kwargs["ok"] = self._kwargs_fixed["ok"]
                 else:
-                    kwargs['ok'] = args[i]
+                    kwargs["ok"] = args[i]
                     i += 1
         if self._ppn_sampling is True:
-            if 'gamma_ppn' in self._kwargs_fixed:
-                kwargs['gamma_ppn'] = self._kwargs_fixed['gamma_ppn']
+            if "gamma_ppn" in self._kwargs_fixed:
+                kwargs["gamma_ppn"] = self._kwargs_fixed["gamma_ppn"]
             else:
-                kwargs['gamma_ppn'] = args[i]
+                kwargs["gamma_ppn"] = args[i]
                 i += 1
         return kwargs, i
 
@@ -130,25 +133,25 @@ class CosmoParam(object):
         """
         args = []
         if self._cosmology not in ["NONE"]:
-            if 'h0' not in self._kwargs_fixed:
-                args.append(kwargs['h0'])
+            if "h0" not in self._kwargs_fixed:
+                args.append(kwargs["h0"])
             if self._cosmology in ["FLCDM", "FwCDM", "w0waCDM", "oLCDM"]:
-                if 'om' not in self._kwargs_fixed:
-                    args.append(kwargs['om'])
+                if "om" not in self._kwargs_fixed:
+                    args.append(kwargs["om"])
             if self._cosmology in ["FwCDM"]:
-                if 'w' not in self._kwargs_fixed:
-                    args.append(kwargs['w'])
+                if "w" not in self._kwargs_fixed:
+                    args.append(kwargs["w"])
             if self._cosmology in ["w0waCDM"]:
-                if 'w0' not in self._kwargs_fixed:
-                    args.append(kwargs['w0'])
-                if 'wa' not in self._kwargs_fixed:
-                    args.append(kwargs['wa'])
+                if "w0" not in self._kwargs_fixed:
+                    args.append(kwargs["w0"])
+                if "wa" not in self._kwargs_fixed:
+                    args.append(kwargs["wa"])
             if self._cosmology in ["oLCDM"]:
-                if 'ok' not in self._kwargs_fixed:
-                    args.append(kwargs['ok'])
+                if "ok" not in self._kwargs_fixed:
+                    args.append(kwargs["ok"])
         if self._ppn_sampling is True:
-            if 'gamma_ppn' not in self._kwargs_fixed:
-                args.append(kwargs['gamma_ppn'])
+            if "gamma_ppn" not in self._kwargs_fixed:
+                args.append(kwargs["gamma_ppn"])
         return args
 
     def cosmo(self, kwargs):
@@ -158,13 +161,23 @@ class CosmoParam(object):
         :return: astropy.cosmology instance
         """
         if self._cosmology == "FLCDM":
-            cosmo = FlatLambdaCDM(H0=kwargs['h0'], Om0=kwargs['om'])
+            cosmo = FlatLambdaCDM(H0=kwargs["h0"], Om0=kwargs["om"])
         elif self._cosmology == "FwCDM":
-            cosmo = FlatwCDM(H0=kwargs['h0'], Om0=kwargs['om'], w0=kwargs['w'])
+            cosmo = FlatwCDM(H0=kwargs["h0"], Om0=kwargs["om"], w0=kwargs["w"])
         elif self._cosmology == "w0waCDM":
-            cosmo = w0waCDM(H0=kwargs['h0'], Om0=kwargs['om'], Ode0=1.0 - kwargs['om'], w0=kwargs['w0'], wa=kwargs['wa'])
+            cosmo = w0waCDM(
+                H0=kwargs["h0"],
+                Om0=kwargs["om"],
+                Ode0=1.0 - kwargs["om"],
+                w0=kwargs["w0"],
+                wa=kwargs["wa"],
+            )
         elif self._cosmology == "oLCDM":
-            cosmo = LambdaCDM(H0=kwargs['h0'], Om0=kwargs['om'], Ode0=1.0 - kwargs['om'] - kwargs['ok'])
+            cosmo = LambdaCDM(
+                H0=kwargs["h0"],
+                Om0=kwargs["om"],
+                Ode0=1.0 - kwargs["om"] - kwargs["ok"],
+            )
         elif self._cosmology == "NONE":
             cosmo = None
         else:

--- a/hierarc/Sampling/ParamManager/kin_param.py
+++ b/hierarc/Sampling/ParamManager/kin_param.py
@@ -2,9 +2,7 @@ import numpy as np
 
 
 class KinParam(object):
-    """
-    manager for the kinematics anisotropy parameters
-    """
+    """Manager for the kinematics anisotropy parameters."""
 
     def __init__(
         self,

--- a/hierarc/Sampling/ParamManager/kin_param.py
+++ b/hierarc/Sampling/ParamManager/kin_param.py
@@ -5,8 +5,16 @@ class KinParam(object):
     """
     manager for the kinematics anisotropy parameters
     """
-    def __init__(self, anisotropy_sampling=False, anisotropy_model='OM', distribution_function='NONE',
-                 sigma_v_systematics=False, log_scatter=False, kwargs_fixed=None):
+
+    def __init__(
+        self,
+        anisotropy_sampling=False,
+        anisotropy_model="OM",
+        distribution_function="NONE",
+        sigma_v_systematics=False,
+        log_scatter=False,
+        kwargs_fixed=None,
+    ):
         """
 
         :param anisotropy_sampling: bool, if True, makes use of this module, else ignores it's functionalities
@@ -18,7 +26,7 @@ class KinParam(object):
         :param log_scatter: boolean, if True, samples the Gaussian scatter amplitude in log space (and thus flat prior in log)
         :param kwargs_fixed: keyword arguments of the fixed parameters
         """
-        assert anisotropy_model in ['NONE', 'GOM', 'OM', 'const']
+        assert anisotropy_model in ["NONE", "GOM", "OM", "const"]
         self._anisotropy_sampling = anisotropy_sampling
         self._anisotropy_model = anisotropy_model
         self._distribution_function = distribution_function
@@ -37,45 +45,45 @@ class KinParam(object):
         """
         list = []
         if self._anisotropy_sampling is True:
-            if self._anisotropy_model in ['OM', 'GOM', 'const']:
-                if 'a_ani' not in self._kwargs_fixed:
+            if self._anisotropy_model in ["OM", "GOM", "const"]:
+                if "a_ani" not in self._kwargs_fixed:
                     if latex_style is True:
-                        list.append(r'$\langle a_{\rm ani}\rangle$')
+                        list.append(r"$\langle a_{\rm ani}\rangle$")
                     else:
-                        list.append('a_ani')
-                if self._distribution_function in ['GAUSSIAN']:
-                    if 'a_ani_sigma' not in self._kwargs_fixed:
+                        list.append("a_ani")
+                if self._distribution_function in ["GAUSSIAN"]:
+                    if "a_ani_sigma" not in self._kwargs_fixed:
                         if latex_style is True:
                             if self._log_scatter is True:
-                                list.append(r'$\log_{10}\sigma(a_{\rm ani})$')
+                                list.append(r"$\log_{10}\sigma(a_{\rm ani})$")
                             else:
-                                list.append(r'$\sigma(a_{\rm ani})$')
+                                list.append(r"$\sigma(a_{\rm ani})$")
                         else:
-                            list.append('a_ani_sigma')
-            if self._anisotropy_model in ['GOM']:
-                if 'beta_inf' not in self._kwargs_fixed:
+                            list.append("a_ani_sigma")
+            if self._anisotropy_model in ["GOM"]:
+                if "beta_inf" not in self._kwargs_fixed:
                     if latex_style is True:
-                        list.append(r'$\beta_{\infty}$')
+                        list.append(r"$\beta_{\infty}$")
                     else:
-                        list.append('beta_inf')
-                if self._distribution_function in ['GAUSSIAN']:
-                    if 'beta_inf_sigma' not in self._kwargs_fixed:
+                        list.append("beta_inf")
+                if self._distribution_function in ["GAUSSIAN"]:
+                    if "beta_inf_sigma" not in self._kwargs_fixed:
                         if latex_style is True:
                             if self._log_scatter is True:
-                                list.append(r'$\log_{10}\sigma(\beta_{\infty})$')
+                                list.append(r"$\log_{10}\sigma(\beta_{\infty})$")
                             else:
-                                list.append(r'$\sigma(\beta_{\infty})$')
+                                list.append(r"$\sigma(\beta_{\infty})$")
                         else:
-                            list.append('beta_inf_sigma')
+                            list.append("beta_inf_sigma")
         if self._sigma_v_systematics is True:
-            if 'sigma_v_sys_error' not in self._kwargs_fixed:
+            if "sigma_v_sys_error" not in self._kwargs_fixed:
                 if latex_style is True:
                     if self._log_scatter is True:
-                        list.append(r'$\log_{10}\sigma_{\rm sys}(\sigma_v)$')
+                        list.append(r"$\log_{10}\sigma_{\rm sys}(\sigma_v)$")
                     else:
-                        list.append(r'$\sigma_{\rm sys}(\sigma_v)$')
+                        list.append(r"$\sigma_{\rm sys}(\sigma_v)$")
                 else:
-                    list.append('sigma_v_sys_error')
+                    list.append("sigma_v_sys_error")
         return list
 
     def args2kwargs(self, args, i=0):
@@ -87,44 +95,44 @@ class KinParam(object):
         """
         kwargs = {}
         if self._anisotropy_sampling is True:
-            if self._anisotropy_model in ['OM', 'GOM', 'const']:
-                if 'a_ani' in self._kwargs_fixed:
-                    kwargs['a_ani'] = self._kwargs_fixed['a_ani']
+            if self._anisotropy_model in ["OM", "GOM", "const"]:
+                if "a_ani" in self._kwargs_fixed:
+                    kwargs["a_ani"] = self._kwargs_fixed["a_ani"]
                 else:
-                    kwargs['a_ani'] = args[i]
+                    kwargs["a_ani"] = args[i]
                     i += 1
-                if self._distribution_function in ['GAUSSIAN']:
-                    if 'a_ani_sigma' in self._kwargs_fixed:
-                        kwargs['a_ani_sigma'] = self._kwargs_fixed['a_ani_sigma']
+                if self._distribution_function in ["GAUSSIAN"]:
+                    if "a_ani_sigma" in self._kwargs_fixed:
+                        kwargs["a_ani_sigma"] = self._kwargs_fixed["a_ani_sigma"]
                     else:
                         if self._log_scatter is True:
-                            kwargs['a_ani_sigma'] = 10**(args[i])
+                            kwargs["a_ani_sigma"] = 10 ** (args[i])
                         else:
-                            kwargs['a_ani_sigma'] = args[i]
+                            kwargs["a_ani_sigma"] = args[i]
                         i += 1
-            if self._anisotropy_model in ['GOM']:
-                if 'beta_inf' in self._kwargs_fixed:
-                    kwargs['beta_inf'] = self._kwargs_fixed['beta_inf']
+            if self._anisotropy_model in ["GOM"]:
+                if "beta_inf" in self._kwargs_fixed:
+                    kwargs["beta_inf"] = self._kwargs_fixed["beta_inf"]
                 else:
-                    kwargs['beta_inf'] = args[i]
+                    kwargs["beta_inf"] = args[i]
                     i += 1
-                if self._distribution_function in ['GAUSSIAN']:
-                    if 'beta_inf_sigma' in self._kwargs_fixed:
-                        kwargs['beta_inf_sigma'] = self._kwargs_fixed['beta_inf_sigma']
+                if self._distribution_function in ["GAUSSIAN"]:
+                    if "beta_inf_sigma" in self._kwargs_fixed:
+                        kwargs["beta_inf_sigma"] = self._kwargs_fixed["beta_inf_sigma"]
                     else:
                         if self._log_scatter is True:
-                            kwargs['beta_inf_sigma'] = 10**(args[i])
+                            kwargs["beta_inf_sigma"] = 10 ** (args[i])
                         else:
-                            kwargs['beta_inf_sigma'] = args[i]
+                            kwargs["beta_inf_sigma"] = args[i]
                         i += 1
         if self._sigma_v_systematics is True:
-            if 'sigma_v_sys_error' in self._kwargs_fixed:
-                kwargs['sigma_v_sys_error'] = self._kwargs_fixed['sigma_v_sys_error']
+            if "sigma_v_sys_error" in self._kwargs_fixed:
+                kwargs["sigma_v_sys_error"] = self._kwargs_fixed["sigma_v_sys_error"]
             else:
                 if self._log_scatter is True:
-                    kwargs['sigma_v_sys_error'] = 10**(args[i])
+                    kwargs["sigma_v_sys_error"] = 10 ** (args[i])
                 else:
-                    kwargs['sigma_v_sys_error'] = args[i]
+                    kwargs["sigma_v_sys_error"] = args[i]
                 i += 1
         return kwargs, i
 
@@ -136,28 +144,28 @@ class KinParam(object):
         """
         args = []
         if self._anisotropy_sampling is True:
-            if self._anisotropy_model in ['OM', 'GOM', 'const']:
-                if 'a_ani' not in self._kwargs_fixed:
-                    args.append(kwargs['a_ani'])
-                if self._distribution_function in ['GAUSSIAN']:
-                    if 'a_ani_sigma' not in self._kwargs_fixed:
+            if self._anisotropy_model in ["OM", "GOM", "const"]:
+                if "a_ani" not in self._kwargs_fixed:
+                    args.append(kwargs["a_ani"])
+                if self._distribution_function in ["GAUSSIAN"]:
+                    if "a_ani_sigma" not in self._kwargs_fixed:
                         if self._log_scatter is True:
-                            args.append(np.log10(kwargs['a_ani_sigma']))
+                            args.append(np.log10(kwargs["a_ani_sigma"]))
                         else:
-                            args.append(kwargs['a_ani_sigma'])
-            if self._anisotropy_model in ['GOM']:
-                if 'beta_inf' not in self._kwargs_fixed:
-                    args.append(kwargs['beta_inf'])
-                if self._distribution_function in ['GAUSSIAN']:
-                    if 'beta_inf_sigma' not in self._kwargs_fixed:
+                            args.append(kwargs["a_ani_sigma"])
+            if self._anisotropy_model in ["GOM"]:
+                if "beta_inf" not in self._kwargs_fixed:
+                    args.append(kwargs["beta_inf"])
+                if self._distribution_function in ["GAUSSIAN"]:
+                    if "beta_inf_sigma" not in self._kwargs_fixed:
                         if self._log_scatter is True:
-                            args.append(np.log10(kwargs['beta_inf_sigma']))
+                            args.append(np.log10(kwargs["beta_inf_sigma"]))
                         else:
-                            args.append(kwargs['beta_inf_sigma'])
+                            args.append(kwargs["beta_inf_sigma"])
         if self._sigma_v_systematics is True:
-            if 'sigma_v_sys_error' not in self._kwargs_fixed:
+            if "sigma_v_sys_error" not in self._kwargs_fixed:
                 if self._log_scatter is True:
-                    args.append(np.log10(kwargs['sigma_v_sys_error']))
+                    args.append(np.log10(kwargs["sigma_v_sys_error"]))
                 else:
-                    args.append(kwargs['sigma_v_sys_error'])
+                    args.append(kwargs["sigma_v_sys_error"])
         return args

--- a/hierarc/Sampling/ParamManager/lens_param.py
+++ b/hierarc/Sampling/ParamManager/lens_param.py
@@ -2,9 +2,7 @@ import numpy as np
 
 
 class LensParam(object):
-    """
-    manages the lens model covariant parameters
-    """
+    """Manages the lens model covariant parameters."""
 
     def __init__(
         self,

--- a/hierarc/Sampling/ParamManager/lens_param.py
+++ b/hierarc/Sampling/ParamManager/lens_param.py
@@ -5,9 +5,20 @@ class LensParam(object):
     """
     manages the lens model covariant parameters
     """
-    def __init__(self, lambda_mst_sampling=False, lambda_mst_distribution='NONE', kappa_ext_sampling=False,
-                 kappa_ext_distribution='NONE', lambda_ifu_sampling=False, lambda_ifu_distribution='NONE',
-                 alpha_lambda_sampling=False, beta_lambda_sampling=False, kwargs_fixed=None, log_scatter=False):
+
+    def __init__(
+        self,
+        lambda_mst_sampling=False,
+        lambda_mst_distribution="NONE",
+        kappa_ext_sampling=False,
+        kappa_ext_distribution="NONE",
+        lambda_ifu_sampling=False,
+        lambda_ifu_distribution="NONE",
+        alpha_lambda_sampling=False,
+        beta_lambda_sampling=False,
+        kwargs_fixed=None,
+        log_scatter=False,
+    ):
         """
 
         :param lambda_mst_sampling: bool, if True adds a global mass-sheet transform parameter in the sampling
@@ -45,59 +56,59 @@ class LensParam(object):
         """
         list = []
         if self._lambda_mst_sampling is True:
-            if 'lambda_mst' not in self._kwargs_fixed:
+            if "lambda_mst" not in self._kwargs_fixed:
                 if latex_style is True:
-                    list.append(r'$\overline{\lambda}_{\rm int}$')
+                    list.append(r"$\overline{\lambda}_{\rm int}$")
                 else:
-                    list.append('lambda_mst')
-            if self._lambda_mst_distribution == 'GAUSSIAN':
-                if 'lambda_mst_sigma' not in self._kwargs_fixed:
+                    list.append("lambda_mst")
+            if self._lambda_mst_distribution == "GAUSSIAN":
+                if "lambda_mst_sigma" not in self._kwargs_fixed:
                     if latex_style is True:
                         if self._log_scatter is True:
-                            list.append(r'$\log_{10}\sigma(\lambda_{\rm int})$')
+                            list.append(r"$\log_{10}\sigma(\lambda_{\rm int})$")
                         else:
-                            list.append(r'$\sigma(\lambda_{\rm int})$')
+                            list.append(r"$\sigma(\lambda_{\rm int})$")
                     else:
-                        list.append('lambda_mst_sigma')
+                        list.append("lambda_mst_sigma")
         if self._lambda_ifu_sampling is True:
-            if 'lambda_ifu' not in self._kwargs_fixed:
+            if "lambda_ifu" not in self._kwargs_fixed:
                 if latex_style is True:
-                    list.append(r'$\lambda_{\rm ifu}$')
+                    list.append(r"$\lambda_{\rm ifu}$")
                 else:
-                    list.append('lambda_ifu')
-            if self._lambda_ifu_distribution == 'GAUSSIAN':
-                if 'lambda_ifu_sigma' not in self._kwargs_fixed:
+                    list.append("lambda_ifu")
+            if self._lambda_ifu_distribution == "GAUSSIAN":
+                if "lambda_ifu_sigma" not in self._kwargs_fixed:
                     if latex_style is True:
                         if self._log_scatter is True:
-                            list.append(r'$\log_{10}\sigma(\lambda_{\rm ifu})$')
+                            list.append(r"$\log_{10}\sigma(\lambda_{\rm ifu})$")
                         else:
-                            list.append(r'$\sigma(\lambda_{\rm ifu})$')
+                            list.append(r"$\sigma(\lambda_{\rm ifu})$")
                     else:
-                        list.append('lambda_ifu_sigma')
+                        list.append("lambda_ifu_sigma")
         if self._kappa_ext_sampling is True:
-            if 'kappa_ext' not in self._kwargs_fixed:
+            if "kappa_ext" not in self._kwargs_fixed:
                 if latex_style is True:
-                    list.append(r'$\overline{\kappa}_{\rm ext}$')
+                    list.append(r"$\overline{\kappa}_{\rm ext}$")
                 else:
-                    list.append('kappa_ext')
-            if self._kappa_ext_distribution == 'GAUSSIAN':
-                if 'kappa_ext_sigma' not in self._kwargs_fixed:
+                    list.append("kappa_ext")
+            if self._kappa_ext_distribution == "GAUSSIAN":
+                if "kappa_ext_sigma" not in self._kwargs_fixed:
                     if latex_style is True:
-                        list.append(r'$\sigma(\kappa_{\rm ext})$')
+                        list.append(r"$\sigma(\kappa_{\rm ext})$")
                     else:
-                        list.append('kappa_ext_sigma')
+                        list.append("kappa_ext_sigma")
         if self._alpha_lambda_sampling is True:
-            if 'alpha_lambda' not in self._kwargs_fixed:
+            if "alpha_lambda" not in self._kwargs_fixed:
                 if latex_style is True:
-                    list.append(r'$\alpha_{\lambda}$')
+                    list.append(r"$\alpha_{\lambda}$")
                 else:
-                    list.append('alpha_lambda')
+                    list.append("alpha_lambda")
         if self._beta_lambda_sampling is True:
-            if 'beta_lambda' not in self._kwargs_fixed:
+            if "beta_lambda" not in self._kwargs_fixed:
                 if latex_style is True:
-                    list.append(r'$\beta_{\lambda}$')
+                    list.append(r"$\beta_{\lambda}$")
                 else:
-                    list.append('beta_lambda')
+                    list.append("beta_lambda")
         return list
 
     def args2kwargs(self, args, i=0):
@@ -108,58 +119,58 @@ class LensParam(object):
         """
         kwargs = {}
         if self._lambda_mst_sampling is True:
-            if 'lambda_mst' in self._kwargs_fixed:
-                kwargs['lambda_mst'] = self._kwargs_fixed['lambda_mst']
+            if "lambda_mst" in self._kwargs_fixed:
+                kwargs["lambda_mst"] = self._kwargs_fixed["lambda_mst"]
             else:
-                kwargs['lambda_mst'] = args[i]
+                kwargs["lambda_mst"] = args[i]
                 i += 1
-            if self._lambda_mst_distribution == 'GAUSSIAN':
-                if 'lambda_mst_sigma' in self._kwargs_fixed:
-                    kwargs['lambda_mst_sigma'] = self._kwargs_fixed['lambda_mst_sigma']
+            if self._lambda_mst_distribution == "GAUSSIAN":
+                if "lambda_mst_sigma" in self._kwargs_fixed:
+                    kwargs["lambda_mst_sigma"] = self._kwargs_fixed["lambda_mst_sigma"]
                 else:
                     if self._log_scatter is True:
-                        kwargs['lambda_mst_sigma'] = 10**(args[i])
+                        kwargs["lambda_mst_sigma"] = 10 ** (args[i])
                     else:
-                        kwargs['lambda_mst_sigma'] = args[i]
+                        kwargs["lambda_mst_sigma"] = args[i]
                     i += 1
         if self._lambda_ifu_sampling is True:
-            if 'lambda_ifu' in self._kwargs_fixed:
-                kwargs['lambda_ifu'] = self._kwargs_fixed['lambda_ifu']
+            if "lambda_ifu" in self._kwargs_fixed:
+                kwargs["lambda_ifu"] = self._kwargs_fixed["lambda_ifu"]
             else:
-                kwargs['lambda_ifu'] = args[i]
+                kwargs["lambda_ifu"] = args[i]
                 i += 1
-            if self._lambda_ifu_distribution == 'GAUSSIAN':
-                if 'lambda_ifu_sigma' in self._kwargs_fixed:
-                    kwargs['lambda_ifu_sigma'] = self._kwargs_fixed['lambda_ifu_sigma']
+            if self._lambda_ifu_distribution == "GAUSSIAN":
+                if "lambda_ifu_sigma" in self._kwargs_fixed:
+                    kwargs["lambda_ifu_sigma"] = self._kwargs_fixed["lambda_ifu_sigma"]
                 else:
                     if self._log_scatter is True:
-                        kwargs['lambda_ifu_sigma'] = 10**(args[i])
+                        kwargs["lambda_ifu_sigma"] = 10 ** (args[i])
                     else:
-                        kwargs['lambda_ifu_sigma'] = args[i]
+                        kwargs["lambda_ifu_sigma"] = args[i]
                     i += 1
         if self._kappa_ext_sampling is True:
-            if 'kappa_ext' in self._kwargs_fixed:
-                kwargs['kappa_ext'] = self._kwargs_fixed['kappa_ext']
+            if "kappa_ext" in self._kwargs_fixed:
+                kwargs["kappa_ext"] = self._kwargs_fixed["kappa_ext"]
             else:
-                kwargs['kappa_ext'] = args[i]
+                kwargs["kappa_ext"] = args[i]
                 i += 1
-            if self._kappa_ext_distribution == 'GAUSSIAN':
-                if 'kappa_ext_sigma' in self._kwargs_fixed:
-                    kwargs['kappa_ext_sigma'] = self._kwargs_fixed['kappa_ext_sigma']
+            if self._kappa_ext_distribution == "GAUSSIAN":
+                if "kappa_ext_sigma" in self._kwargs_fixed:
+                    kwargs["kappa_ext_sigma"] = self._kwargs_fixed["kappa_ext_sigma"]
                 else:
-                    kwargs['kappa_ext_sigma'] = args[i]
+                    kwargs["kappa_ext_sigma"] = args[i]
                     i += 1
         if self._alpha_lambda_sampling is True:
-            if 'alpha_lambda' in self._kwargs_fixed:
-                kwargs['alpha_lambda'] = self._kwargs_fixed['alpha_lambda']
+            if "alpha_lambda" in self._kwargs_fixed:
+                kwargs["alpha_lambda"] = self._kwargs_fixed["alpha_lambda"]
             else:
-                kwargs['alpha_lambda'] = args[i]
+                kwargs["alpha_lambda"] = args[i]
                 i += 1
         if self._beta_lambda_sampling is True:
-            if 'beta_lambda' in self._kwargs_fixed:
-                kwargs['beta_lambda'] = self._kwargs_fixed['beta_lambda']
+            if "beta_lambda" in self._kwargs_fixed:
+                kwargs["beta_lambda"] = self._kwargs_fixed["beta_lambda"]
             else:
-                kwargs['beta_lambda'] = args[i]
+                kwargs["beta_lambda"] = args[i]
                 i += 1
         return kwargs, i
 
@@ -171,33 +182,33 @@ class LensParam(object):
         """
         args = []
         if self._lambda_mst_sampling is True:
-            if 'lambda_mst' not in self._kwargs_fixed:
-                args.append(kwargs['lambda_mst'])
-            if self._lambda_mst_distribution == 'GAUSSIAN':
-                if 'lambda_mst_sigma' not in self._kwargs_fixed:
+            if "lambda_mst" not in self._kwargs_fixed:
+                args.append(kwargs["lambda_mst"])
+            if self._lambda_mst_distribution == "GAUSSIAN":
+                if "lambda_mst_sigma" not in self._kwargs_fixed:
                     if self._log_scatter is True:
-                        args.append(np.log10(kwargs['lambda_mst_sigma']))
+                        args.append(np.log10(kwargs["lambda_mst_sigma"]))
                     else:
-                        args.append(kwargs['lambda_mst_sigma'])
+                        args.append(kwargs["lambda_mst_sigma"])
         if self._lambda_ifu_sampling is True:
-            if 'lambda_ifu' not in self._kwargs_fixed:
-                args.append(kwargs['lambda_ifu'])
-            if self._lambda_ifu_distribution == 'GAUSSIAN':
-                if 'lambda_ifu_sigma' not in self._kwargs_fixed:
+            if "lambda_ifu" not in self._kwargs_fixed:
+                args.append(kwargs["lambda_ifu"])
+            if self._lambda_ifu_distribution == "GAUSSIAN":
+                if "lambda_ifu_sigma" not in self._kwargs_fixed:
                     if self._log_scatter is True:
-                        args.append(np.log10(kwargs['lambda_ifu_sigma']))
+                        args.append(np.log10(kwargs["lambda_ifu_sigma"]))
                     else:
-                        args.append(kwargs['lambda_ifu_sigma'])
+                        args.append(kwargs["lambda_ifu_sigma"])
         if self._kappa_ext_sampling is True:
-            if 'kappa_ext' not in self._kwargs_fixed:
-                args.append(kwargs['kappa_ext'])
-            if self._kappa_ext_distribution == 'GAUSSIAN':
-                if 'kappa_ext_sigma' not in self._kwargs_fixed:
-                    args.append(kwargs['kappa_ext_sigma'])
+            if "kappa_ext" not in self._kwargs_fixed:
+                args.append(kwargs["kappa_ext"])
+            if self._kappa_ext_distribution == "GAUSSIAN":
+                if "kappa_ext_sigma" not in self._kwargs_fixed:
+                    args.append(kwargs["kappa_ext_sigma"])
         if self._alpha_lambda_sampling is True:
-            if 'alpha_lambda' not in self._kwargs_fixed:
-                args.append(kwargs['alpha_lambda'])
+            if "alpha_lambda" not in self._kwargs_fixed:
+                args.append(kwargs["alpha_lambda"])
         if self._beta_lambda_sampling is True:
-            if 'beta_lambda' not in self._kwargs_fixed:
-                args.append(kwargs['beta_lambda'])
+            if "beta_lambda" not in self._kwargs_fixed:
+                args.append(kwargs["beta_lambda"])
         return args

--- a/hierarc/Sampling/ParamManager/param_manager.py
+++ b/hierarc/Sampling/ParamManager/param_manager.py
@@ -8,17 +8,40 @@ class ParamManager(object):
     """
     class for managing the parameters involved
     """
-    def __init__(self, cosmology, ppn_sampling=False, lambda_mst_sampling=False, lambda_mst_distribution='NONE',
-                 anisotropy_sampling=False, anisotropy_model='OM', anisotropy_distribution='NONE',
-                 kappa_ext_sampling=False, kappa_ext_distribution='NONE', lambda_ifu_sampling=False,
-                 lambda_ifu_distribution='NONE', alpha_lambda_sampling=False, beta_lambda_sampling=False,
-                 sigma_v_systematics=False,
-                 sne_apparent_m_sampling=False, sne_distribution='GAUSSIAN', z_apparent_m_anchor=0.1,
-                 log_scatter=False,
-                 kwargs_lower_cosmo=None, kwargs_upper_cosmo=None,
-                 kwargs_fixed_cosmo=None, kwargs_lower_lens=None, kwargs_upper_lens=None, kwargs_fixed_lens=None,
-                 kwargs_lower_kin=None, kwargs_upper_kin=None, kwargs_fixed_kin=None,
-                 kwargs_lower_source=None, kwargs_upper_source=None, kwargs_fixed_source=None):
+
+    def __init__(
+        self,
+        cosmology,
+        ppn_sampling=False,
+        lambda_mst_sampling=False,
+        lambda_mst_distribution="NONE",
+        anisotropy_sampling=False,
+        anisotropy_model="OM",
+        anisotropy_distribution="NONE",
+        kappa_ext_sampling=False,
+        kappa_ext_distribution="NONE",
+        lambda_ifu_sampling=False,
+        lambda_ifu_distribution="NONE",
+        alpha_lambda_sampling=False,
+        beta_lambda_sampling=False,
+        sigma_v_systematics=False,
+        sne_apparent_m_sampling=False,
+        sne_distribution="GAUSSIAN",
+        z_apparent_m_anchor=0.1,
+        log_scatter=False,
+        kwargs_lower_cosmo=None,
+        kwargs_upper_cosmo=None,
+        kwargs_fixed_cosmo=None,
+        kwargs_lower_lens=None,
+        kwargs_upper_lens=None,
+        kwargs_fixed_lens=None,
+        kwargs_lower_kin=None,
+        kwargs_upper_kin=None,
+        kwargs_fixed_kin=None,
+        kwargs_lower_source=None,
+        kwargs_upper_source=None,
+        kwargs_fixed_source=None,
+    ):
         """
 
         :param cosmology: string describing cosmological model
@@ -44,27 +67,53 @@ class ParamManager(object):
          measurement
         :param log_scatter: boolean, if True, samples the Gaussian scatter amplitude in log space (and thus flat prior in log)
         """
-        self._kin_param = KinParam(anisotropy_sampling=anisotropy_sampling, anisotropy_model=anisotropy_model,
-                                   distribution_function=anisotropy_distribution, log_scatter=log_scatter,
-                                   sigma_v_systematics=sigma_v_systematics, kwargs_fixed=kwargs_fixed_kin)
-        self._cosmo_param = CosmoParam(cosmology=cosmology, ppn_sampling=ppn_sampling, kwargs_fixed=kwargs_fixed_cosmo)
-        self._lens_param = LensParam(lambda_mst_sampling=lambda_mst_sampling,
-                                     lambda_mst_distribution=lambda_mst_distribution,
-                                     lambda_ifu_sampling=lambda_ifu_sampling,
-                                     lambda_ifu_distribution=lambda_ifu_distribution,
-                                     kappa_ext_sampling=kappa_ext_sampling,
-                                     kappa_ext_distribution=kappa_ext_distribution,
-                                     alpha_lambda_sampling=alpha_lambda_sampling,
-                                     beta_lambda_sampling=beta_lambda_sampling,
-                                     log_scatter=log_scatter,
-                                     kwargs_fixed=kwargs_fixed_lens)
-        self._source_param = SourceParam(sne_apparent_m_sampling=sne_apparent_m_sampling,
-                                         sne_distribution=sne_distribution, z_apparent_m_anchor=z_apparent_m_anchor,
-                                         kwargs_fixed=kwargs_fixed_source)
-        self._kwargs_upper_cosmo, self._kwargs_lower_cosmo = kwargs_upper_cosmo, kwargs_lower_cosmo
-        self._kwargs_upper_lens, self._kwargs_lower_lens = kwargs_upper_lens, kwargs_lower_lens
-        self._kwargs_upper_kin, self._kwargs_lower_kin = kwargs_upper_kin, kwargs_lower_kin
-        self._kwargs_upper_source, self._kwargs_lower_source = kwargs_upper_source, kwargs_lower_source
+        self._kin_param = KinParam(
+            anisotropy_sampling=anisotropy_sampling,
+            anisotropy_model=anisotropy_model,
+            distribution_function=anisotropy_distribution,
+            log_scatter=log_scatter,
+            sigma_v_systematics=sigma_v_systematics,
+            kwargs_fixed=kwargs_fixed_kin,
+        )
+        self._cosmo_param = CosmoParam(
+            cosmology=cosmology,
+            ppn_sampling=ppn_sampling,
+            kwargs_fixed=kwargs_fixed_cosmo,
+        )
+        self._lens_param = LensParam(
+            lambda_mst_sampling=lambda_mst_sampling,
+            lambda_mst_distribution=lambda_mst_distribution,
+            lambda_ifu_sampling=lambda_ifu_sampling,
+            lambda_ifu_distribution=lambda_ifu_distribution,
+            kappa_ext_sampling=kappa_ext_sampling,
+            kappa_ext_distribution=kappa_ext_distribution,
+            alpha_lambda_sampling=alpha_lambda_sampling,
+            beta_lambda_sampling=beta_lambda_sampling,
+            log_scatter=log_scatter,
+            kwargs_fixed=kwargs_fixed_lens,
+        )
+        self._source_param = SourceParam(
+            sne_apparent_m_sampling=sne_apparent_m_sampling,
+            sne_distribution=sne_distribution,
+            z_apparent_m_anchor=z_apparent_m_anchor,
+            kwargs_fixed=kwargs_fixed_source,
+        )
+        self._kwargs_upper_cosmo, self._kwargs_lower_cosmo = (
+            kwargs_upper_cosmo,
+            kwargs_lower_cosmo,
+        )
+        self._kwargs_upper_lens, self._kwargs_lower_lens = (
+            kwargs_upper_lens,
+            kwargs_lower_lens,
+        )
+        self._kwargs_upper_kin, self._kwargs_lower_kin = (
+            kwargs_upper_kin,
+            kwargs_lower_kin,
+        )
+        self._kwargs_upper_source, self._kwargs_lower_source = (
+            kwargs_upper_source,
+            kwargs_lower_source,
+        )
 
     @property
     def num_param(self):
@@ -101,7 +150,9 @@ class ParamManager(object):
         kwargs_source, i = self._source_param.args2kwargs(args, i=i)
         return kwargs_cosmo, kwargs_lens, kwargs_kin, kwargs_source
 
-    def kwargs2args(self, kwargs_cosmo=None, kwargs_lens=None, kwargs_kin=None, kwargs_source=None):
+    def kwargs2args(
+        self, kwargs_cosmo=None, kwargs_lens=None, kwargs_kin=None, kwargs_source=None
+    ):
         """
 
         :param kwargs_cosmo: keyword argument list of parameters for cosmology sampling
@@ -131,8 +182,16 @@ class ParamManager(object):
 
         :return: argument list of the hard bounds in the order of the sampling
         """
-        lower_limit = self.kwargs2args(kwargs_cosmo=self._kwargs_lower_cosmo, kwargs_lens=self._kwargs_lower_lens,
-                                       kwargs_kin=self._kwargs_lower_kin, kwargs_source=self._kwargs_lower_source)
-        upper_limit = self.kwargs2args(kwargs_cosmo=self._kwargs_upper_cosmo, kwargs_lens=self._kwargs_upper_lens,
-                                       kwargs_kin=self._kwargs_upper_kin, kwargs_source=self._kwargs_upper_source)
+        lower_limit = self.kwargs2args(
+            kwargs_cosmo=self._kwargs_lower_cosmo,
+            kwargs_lens=self._kwargs_lower_lens,
+            kwargs_kin=self._kwargs_lower_kin,
+            kwargs_source=self._kwargs_lower_source,
+        )
+        upper_limit = self.kwargs2args(
+            kwargs_cosmo=self._kwargs_upper_cosmo,
+            kwargs_lens=self._kwargs_upper_lens,
+            kwargs_kin=self._kwargs_upper_kin,
+            kwargs_source=self._kwargs_upper_source,
+        )
         return lower_limit, upper_limit

--- a/hierarc/Sampling/ParamManager/param_manager.py
+++ b/hierarc/Sampling/ParamManager/param_manager.py
@@ -5,9 +5,7 @@ from hierarc.Sampling.ParamManager.source_param import SourceParam
 
 
 class ParamManager(object):
-    """
-    class for managing the parameters involved
-    """
+    """Class for managing the parameters involved."""
 
     def __init__(
         self,
@@ -117,8 +115,7 @@ class ParamManager(object):
 
     @property
     def num_param(self):
-        """
-        number of parameters being sampled
+        """Number of parameters being sampled.
 
         :return: integer
         """

--- a/hierarc/Sampling/ParamManager/source_param.py
+++ b/hierarc/Sampling/ParamManager/source_param.py
@@ -1,13 +1,18 @@
-
-_SNE_DISTRIBUTIONS = ['GAUSSIAN', 'NONE']
+_SNE_DISTRIBUTIONS = ["GAUSSIAN", "NONE"]
 
 
 class SourceParam(object):
     """
     manager for the source property parameters (currently particularly source magnitudes for SNe)
     """
-    def __init__(self, sne_apparent_m_sampling=False, sne_distribution='GAUSSIAN', kwargs_fixed=None,
-                 z_apparent_m_anchor=0.1):
+
+    def __init__(
+        self,
+        sne_apparent_m_sampling=False,
+        sne_distribution="GAUSSIAN",
+        kwargs_fixed=None,
+        z_apparent_m_anchor=0.1,
+    ):
         """
 
         :param sne_apparent_m_sampling: boolean, if True, samples/queries SNe unlensed magnitude distribution
@@ -21,7 +26,10 @@ class SourceParam(object):
         """
         self._sne_apparent_m_sampling = sne_apparent_m_sampling
         if sne_distribution not in _SNE_DISTRIBUTIONS:
-            raise ValueError('SNE distribution %s not supported. Please chose among %s.' % (sne_distribution, _SNE_DISTRIBUTIONS))
+            raise ValueError(
+                "SNE distribution %s not supported. Please chose among %s."
+                % (sne_distribution, _SNE_DISTRIBUTIONS)
+            )
         self._sne_distribution = sne_distribution
         if kwargs_fixed is None:
             kwargs_fixed = {}
@@ -37,17 +45,17 @@ class SourceParam(object):
         """
         name_list = []
         if self._sne_apparent_m_sampling is True:
-            if 'mu_sne' not in self._kwargs_fixed:
+            if "mu_sne" not in self._kwargs_fixed:
                 if latex_style is True:
-                    name_list.append(r'$\overline{m}_{\rm p}$')
+                    name_list.append(r"$\overline{m}_{\rm p}$")
                 else:
-                    name_list.append('mu_sne')
-            if self._sne_distribution in ['GAUSSIAN']:
-                if 'sigma_sne' not in self._kwargs_fixed:
+                    name_list.append("mu_sne")
+            if self._sne_distribution in ["GAUSSIAN"]:
+                if "sigma_sne" not in self._kwargs_fixed:
                     if latex_style is True:
-                        name_list.append(r'$\sigma(m_{\rm p})$')
+                        name_list.append(r"$\sigma(m_{\rm p})$")
                     else:
-                        name_list.append('sigma_sne')
+                        name_list.append("sigma_sne")
         return name_list
 
     def args2kwargs(self, args, i=0):
@@ -59,18 +67,18 @@ class SourceParam(object):
         """
         kwargs = {}
         if self._sne_apparent_m_sampling is True:
-            if 'mu_sne' in self._kwargs_fixed:
-                kwargs['mu_sne'] = self._kwargs_fixed['mu_sne']
+            if "mu_sne" in self._kwargs_fixed:
+                kwargs["mu_sne"] = self._kwargs_fixed["mu_sne"]
             else:
-                kwargs['mu_sne'] = args[i]
+                kwargs["mu_sne"] = args[i]
                 i += 1
-            if self._sne_distribution in ['GAUSSIAN']:
-                if 'sigma_sne' in self._kwargs_fixed:
-                    kwargs['sigma_sne'] = self._kwargs_fixed['sigma_sne']
+            if self._sne_distribution in ["GAUSSIAN"]:
+                if "sigma_sne" in self._kwargs_fixed:
+                    kwargs["sigma_sne"] = self._kwargs_fixed["sigma_sne"]
                 else:
-                    kwargs['sigma_sne'] = args[i]
+                    kwargs["sigma_sne"] = args[i]
                     i += 1
-        kwargs['z_apparent_m_anchor'] = self._z_apparent_m_anchor
+        kwargs["z_apparent_m_anchor"] = self._z_apparent_m_anchor
         return kwargs, i
 
     def kwargs2args(self, kwargs):
@@ -81,9 +89,9 @@ class SourceParam(object):
         """
         args = []
         if self._sne_apparent_m_sampling is True:
-            if 'mu_sne' not in self._kwargs_fixed:
-                args.append(kwargs['mu_sne'])
-            if self._sne_distribution in ['GAUSSIAN']:
-                if 'sigma_sne' not in self._kwargs_fixed:
-                    args.append(kwargs['sigma_sne'])
+            if "mu_sne" not in self._kwargs_fixed:
+                args.append(kwargs["mu_sne"])
+            if self._sne_distribution in ["GAUSSIAN"]:
+                if "sigma_sne" not in self._kwargs_fixed:
+                    args.append(kwargs["sigma_sne"])
         return args

--- a/hierarc/Sampling/ParamManager/source_param.py
+++ b/hierarc/Sampling/ParamManager/source_param.py
@@ -2,9 +2,8 @@ _SNE_DISTRIBUTIONS = ["GAUSSIAN", "NONE"]
 
 
 class SourceParam(object):
-    """
-    manager for the source property parameters (currently particularly source magnitudes for SNe)
-    """
+    """Manager for the source property parameters (currently particularly source
+    magnitudes for SNe)"""
 
     def __init__(
         self,

--- a/hierarc/Sampling/mcmc_sampling.py
+++ b/hierarc/Sampling/mcmc_sampling.py
@@ -7,6 +7,7 @@ class MCMCSampler(object):
     """
     class which executes the different sampling  methods
     """
+
     def __init__(self, *args, **kwargs):
         """
         initialise the classes of the chain and for parameter options
@@ -17,8 +18,16 @@ class MCMCSampler(object):
         self.chain = CosmoLikelihood(*args, **kwargs)
         self.param = self.chain.param
 
-    def mcmc_emcee(self, n_walkers, n_burn, n_run, kwargs_mean_start, kwargs_sigma_start, continue_from_backend=False,
-                   **kwargs_emcee):
+    def mcmc_emcee(
+        self,
+        n_walkers,
+        n_burn,
+        n_run,
+        kwargs_mean_start,
+        kwargs_sigma_start,
+        continue_from_backend=False,
+        **kwargs_emcee
+    ):
         """
         runs the EMCEE MCMC sampling
 
@@ -33,17 +42,19 @@ class MCMCSampler(object):
         """
 
         num_param = self.param.num_param
-        sampler = emcee.EnsembleSampler(n_walkers, num_param, self.chain.likelihood, args=(), **kwargs_emcee)
+        sampler = emcee.EnsembleSampler(
+            n_walkers, num_param, self.chain.likelihood, args=(), **kwargs_emcee
+        )
         mean_start = self.param.kwargs2args(**kwargs_mean_start)
         sigma_start = self.param.kwargs2args(**kwargs_sigma_start)
         p0 = sampling_util.sample_ball(mean_start, sigma_start, n_walkers)
-        backend = kwargs_emcee.get('backend', None)
+        backend = kwargs_emcee.get("backend", None)
         if backend is not None:
             if continue_from_backend:
                 p0 = None
             else:
                 backend.reset(n_walkers, num_param)
-        sampler.run_mcmc(p0, n_burn+n_run, progress=True)
+        sampler.run_mcmc(p0, n_burn + n_run, progress=True)
         flat_samples = sampler.get_chain(discard=n_burn, thin=1, flat=True)
         log_prob = sampler.get_log_prob(discard=n_burn, thin=1, flat=True)
         return flat_samples, log_prob

--- a/hierarc/Sampling/mcmc_sampling.py
+++ b/hierarc/Sampling/mcmc_sampling.py
@@ -4,17 +4,12 @@ from lenstronomy.Util import sampling_util
 
 
 class MCMCSampler(object):
-    """
-    class which executes the different sampling  methods
-    """
+    """Class which executes the different sampling  methods."""
 
     def __init__(self, *args, **kwargs):
-        """
-        initialise the classes of the chain and for parameter options
-        :param args: positional arguments for the CosmoLikelihood() instance
-        :param kwargs: keyword arguments for the CosmoLikelihood() instance
-
-        """
+        """Initialise the classes of the chain and for parameter options :param args:
+        positional arguments for the CosmoLikelihood() instance :param kwargs: keyword
+        arguments for the CosmoLikelihood() instance."""
         self.chain = CosmoLikelihood(*args, **kwargs)
         self.param = self.chain.param
 
@@ -28,15 +23,16 @@ class MCMCSampler(object):
         continue_from_backend=False,
         **kwargs_emcee
     ):
-        """
-        runs the EMCEE MCMC sampling
+        """Runs the EMCEE MCMC sampling.
 
         :param n_walkers: number of walkers
         :param n_burn: number of iteration of burn in (not stored in the output sample
         :param n_run: number of iterations (after burn in) to be sampled
         :param kwargs_mean_start: keyword arguments of the mean starting position
-        :param kwargs_sigma_start: keyword arguments of the spread in the initial particles per parameter
-        :param continue_from_backend: bool, if True and 'backend' in kwargs_emcee, will continue a chain sampling from backend
+        :param kwargs_sigma_start: keyword arguments of the spread in the initial
+            particles per parameter
+        :param continue_from_backend: bool, if True and 'backend' in kwargs_emcee, will
+            continue a chain sampling from backend
         :param kwargs_emcee: keyword argument for the emcee (e.g. to specify backend)
         :return: samples of the EMCEE run
         """
@@ -60,10 +56,10 @@ class MCMCSampler(object):
         return flat_samples, log_prob
 
     def param_names(self, latex_style=False):
-        """
-        list of parameter names being sampled in the same order as the sampling
+        """List of parameter names being sampled in the same order as the sampling.
 
-        :param latex_style: bool, if True returns strings in latex symbols, else in the convention of the sampler
+        :param latex_style: bool, if True returns strings in latex symbols, else in the
+            convention of the sampler
         :return: list of strings
         """
         labels = self.param.param_list(latex_style=latex_style)

--- a/hierarc/Util/distribution_util.py
+++ b/hierarc/Util/distribution_util.py
@@ -3,9 +3,7 @@ from scipy.interpolate import interp1d
 
 
 class PDFSampling(object):
-    """
-    class for approximations with a given pdf sample
-    """
+    """Class for approximations with a given pdf sample."""
 
     def __init__(self, bin_edges, pdf_array):
         """

--- a/hierarc/Util/distribution_util.py
+++ b/hierarc/Util/distribution_util.py
@@ -6,6 +6,7 @@ class PDFSampling(object):
     """
     class for approximations with a given pdf sample
     """
+
     def __init__(self, bin_edges, pdf_array):
         """
 
@@ -13,7 +14,9 @@ class PDFSampling(object):
         :param pdf_array: pdf array of given bins (len(bin_edges)-1)
         """
         assert len(bin_edges) == len(pdf_array) + 1
-        self._cdf_array, self._cdf_func, self._cdf_inv_func = approx_cdf_1d(bin_edges, pdf_array)
+        self._cdf_array, self._cdf_func, self._cdf_inv_func = approx_cdf_1d(
+            bin_edges, pdf_array
+        )
 
     def draw(self, n=1):
         """
@@ -33,7 +36,6 @@ class PDFSampling(object):
 
 
 def approx_cdf_1d(bin_edges, pdf_array):
-
     """
 
     :param bin_edges: bin edges of PDF values
@@ -41,11 +43,11 @@ def approx_cdf_1d(bin_edges, pdf_array):
     :return: cdf, interp1d function of cdf, inverse interpolation function
     """
     assert len(bin_edges) == len(pdf_array) + 1
-    norm_pdf = pdf_array/np.sum(pdf_array)
+    norm_pdf = pdf_array / np.sum(pdf_array)
     cdf_array = np.zeros_like(bin_edges)
     cdf_array[0] = 0
     for i in range(0, len(norm_pdf)):
-        cdf_array[i+1] = cdf_array[i] + norm_pdf[i]
+        cdf_array[i + 1] = cdf_array[i] + norm_pdf[i]
     cdf_func = interp1d(bin_edges, cdf_array)
     cdf_inv_func = interp1d(cdf_array, bin_edges)
     return cdf_array, cdf_func, cdf_inv_func

--- a/hierarc/Util/ifu_util.py
+++ b/hierarc/Util/ifu_util.py
@@ -1,7 +1,5 @@
-"""
-this file contains routines to process the data format of the SLACS IFU data set to be binned in radial annuli
-and for error estimates
-"""
+"""This file contains routines to process the data format of the SLACS IFU data set to
+be binned in radial annuli and for error estimates."""
 import numpy as np
 import astropy.io.fits as fits
 
@@ -105,9 +103,7 @@ def binned_total(
 
 
 def _2d_t0_1d(value_map, weight_map, flux_map, fiber_scale):
-    """
-    transforms map in 1-d array removing nans and artifacts
-
+    """Transforms map in 1-d array removing nans and artifacts.
 
     :param value_map: quantity (e.g. velocity dispersion or velocity) on the map level
     :param weight_map:

--- a/hierarc/Util/ifu_util.py
+++ b/hierarc/Util/ifu_util.py
@@ -16,7 +16,9 @@ def binned_dispersion(dispersion_map, weight_map, flux_map, fiber_scale, r_bins)
     :param r_bins: array, bins in radial directions
     :return: averaged velocity dispersion measurement for each radial bin and estimated uncertainty thereof
     """
-    radial_pos, dispersion, error_weight, flux = _2d_t0_1d(dispersion_map, weight_map, flux_map, fiber_scale)
+    radial_pos, dispersion, error_weight, flux = _2d_t0_1d(
+        dispersion_map, weight_map, flux_map, fiber_scale
+    )
     r_in = r_bins[0]
     disp_r = []
     weight_r = []
@@ -25,7 +27,8 @@ def binned_dispersion(dispersion_map, weight_map, flux_map, fiber_scale, r_bins)
     for i, r_out in enumerate(r_bins[1:]):
         index = np.where((radial_pos >= r_in) & (radial_pos < r_out))
         disp = np.sum(dispersion[index] * error_weight[index] * flux[index]) / np.sum(
-            error_weight[index] * flux[index])
+            error_weight[index] * flux[index]
+        )
         disp_r.append(disp)
         weight_r.append(np.sum(error_weight[index] * flux[index]) / np.sum(flux[index]))
         r_in = r_out
@@ -42,24 +45,39 @@ def binned_velocity(velocity_map, weight_map, flux_map, fiber_scale, r_bins):
     :param r_bins: array, bins in radial directions
     :return: average velocity components with luminosity weights, weight on v^2 error
     """
-    radial_pos, velocity, error_weight, flux = _2d_t0_1d(velocity_map, weight_map, flux_map, fiber_scale)
+    radial_pos, velocity, error_weight, flux = _2d_t0_1d(
+        velocity_map, weight_map, flux_map, fiber_scale
+    )
     r_in = r_bins[0]
     v2_r = []
-    error_weight_v2 = error_weight / (2 * np.abs(velocity))  # error on v^2 based on error on v, 1/sigma^2(v^2) = 1/sigma^2(v) / (2 * v)
+    error_weight_v2 = error_weight / (
+        2 * np.abs(velocity)
+    )  # error on v^2 based on error on v, 1/sigma^2(v^2) = 1/sigma^2(v) / (2 * v)
     weight_r = []
     for i, r_out in enumerate(r_bins[1:]):
         index = np.where((radial_pos >= r_in) & (radial_pos < r_out))
-        v2 = np.sum(velocity[index] ** 2 * error_weight_v2[index] * flux[index]) / np.sum(
-            error_weight_v2[index] * flux[index])
+        v2 = np.sum(
+            velocity[index] ** 2 * error_weight_v2[index] * flux[index]
+        ) / np.sum(error_weight_v2[index] * flux[index])
         v2_r.append(v2)
-        weight_r.append(np.sum(error_weight_v2[index] * flux[index]) / np.sum(flux[index]))
+        weight_r.append(
+            np.sum(error_weight_v2[index] * flux[index]) / np.sum(flux[index])
+        )
         r_in = r_out
     v_r = np.sqrt(np.array(v2_r))
     weight_v = np.array(weight_r) * (2 * v_r)
     return v_r, weight_v
 
 
-def binned_total(dispersion_map, weight_map_disp, velocity_map, weight_map_v, flux_map, fiber_scale, r_bins):
+def binned_total(
+    dispersion_map,
+    weight_map_disp,
+    velocity_map,
+    weight_map_v,
+    flux_map,
+    fiber_scale,
+    r_bins,
+):
     """
 
     :param dispersion_map: 2d array of measured velocity dispersion for each fiber
@@ -71,11 +89,17 @@ def binned_total(dispersion_map, weight_map_disp, velocity_map, weight_map_v, fl
     :param r_bins: array, bins in radial directions
     :return: sqrt(v^2 + sigma^2) averaged integrated line dispersion when averaged over azimuthal bins
     """
-    v_r, weight_v_r = binned_velocity(velocity_map, weight_map_v, flux_map, fiber_scale, r_bins)
-    disp_r, weight_disp_r = binned_dispersion(dispersion_map, weight_map_disp, flux_map, fiber_scale, r_bins)
+    v_r, weight_v_r = binned_velocity(
+        velocity_map, weight_map_v, flux_map, fiber_scale, r_bins
+    )
+    disp_r, weight_disp_r = binned_dispersion(
+        dispersion_map, weight_map_disp, flux_map, fiber_scale, r_bins
+    )
 
-    disp_tot = np.sqrt(v_r ** 2 + disp_r ** 2)  # total measured dispersion integrated over velocity and local dispersion
-    weight_tot = (weight_disp_r * disp_r ** 2 + weight_v_r * v_r ** 2) / disp_tot ** 2
+    disp_tot = np.sqrt(
+        v_r**2 + disp_r**2
+    )  # total measured dispersion integrated over velocity and local dispersion
+    weight_tot = (weight_disp_r * disp_r**2 + weight_v_r * v_r**2) / disp_tot**2
     disp_error = 1 / np.sqrt(weight_tot)
     return disp_tot, disp_error
 
@@ -107,6 +131,10 @@ def _2d_t0_1d(value_map, weight_map, flux_map, fiber_scale):
                 disp_list.append(disp)
                 weight_list.append(weight_map[i, j])
                 flux_list.append(flux_map[i, j])
-    r_list, disp_list, weight_list, flux_list = np.array(r_list), np.array(disp_list), np.array(weight_list), np.array(
-        flux_list)
+    r_list, disp_list, weight_list, flux_list = (
+        np.array(r_list),
+        np.array(disp_list),
+        np.array(weight_list),
+        np.array(flux_list),
+    )
     return r_list, disp_list, weight_list, flux_list

--- a/hierarc/Util/likelihood_util.py
+++ b/hierarc/Util/likelihood_util.py
@@ -12,7 +12,7 @@ def log_likelihood_cov(data, model, cov_error):
     :return: log likelihood
     """
     delta = data - model
-    return -delta.dot(cov_error.dot(delta)) / 2.
+    return -delta.dot(cov_error.dot(delta)) / 2.0
 
 
 def cov_error_create(error_independent, error_covariance):
@@ -25,7 +25,9 @@ def cov_error_create(error_independent, error_covariance):
     :return: error covariance matrix
     """
     error_covariance_array = np.ones_like(error_independent) * error_covariance
-    error = np.outer(error_covariance_array, error_covariance_array) + np.diag(error_independent**2)
+    error = np.outer(error_covariance_array, error_covariance_array) + np.diag(
+        error_independent**2
+    )
     return np.linalg.inv(error)
 
 
@@ -38,5 +40,4 @@ def get_truncated_normal(mean=0, sd=1, low=0, upp=10, size=1):
     :param upp: upper bound
     :return: float, draw of distribution
     """
-    return truncnorm(
-        (low - mean) / sd, (upp - mean) / sd, loc=mean, scale=sd).rvs(size)
+    return truncnorm((low - mean) / sd, (upp - mean) / sd, loc=mean, scale=sd).rvs(size)

--- a/hierarc/Util/likelihood_util.py
+++ b/hierarc/Util/likelihood_util.py
@@ -3,8 +3,7 @@ from scipy.stats import truncnorm
 
 
 def log_likelihood_cov(data, model, cov_error):
-    """
-    log likelihood of the data given a model
+    """Log likelihood of the data given a model.
 
     :param data: data vector
     :param model: model vector
@@ -16,12 +15,12 @@ def log_likelihood_cov(data, model, cov_error):
 
 
 def cov_error_create(error_independent, error_covariance):
-    """
-    generates an error covariance matrix from a set of independent uncertainties combined with a fully covariant term
+    """Generates an error covariance matrix from a set of independent uncertainties
+    combined with a fully covariant term.
 
     :param error_independent: array of Gaussian 1-sigma uncertainties
-    :param error_covariance: float, shared covariant error among all data points. So if all data points are off by
-     1-sigma, then the log likelihood is 1-sigma
+    :param error_covariance: float, shared covariant error among all data points. So if
+        all data points are off by 1-sigma, then the log likelihood is 1-sigma
     :return: error covariance matrix
     """
     error_covariance_array = np.ones_like(error_independent) * error_covariance

--- a/hierarc/__init__.py
+++ b/hierarc/__init__.py
@@ -1,5 +1,5 @@
 """Top-level package for hierArc."""
 
 __author__ = """Simon Birrer"""
-__email__ = 'sibirrer@gmail.com'
-__version__ = '1.1.2'
+__email__ = "sibirrer@gmail.com"
+__version__ = "1.1.2"

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,10 @@ import sys
 from setuptools.command.test import test as TestCommand
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open("README.rst") as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open("HISTORY.rst") as history_file:
     history = history_file.read()
 
 
@@ -21,47 +21,50 @@ class PyTest(TestCommand):
 
     def run_tests(self):
         import pytest
+
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
 
-requirements = ['numpy>=1.13', 'scipy>=0.14.0']
+requirements = ["numpy>=1.13", "scipy>=0.14.0"]
 
 setup_requirements = []
 
-test_requirements = ['pytest>=3', ]
+test_requirements = [
+    "pytest>=3",
+]
 
 PACKAGE_PATH = os.path.abspath(os.path.join(__file__, os.pardir))
 
 setup(
     author="Simon Birrer",
-    author_email='sibirrer@gmail.com',
-    python_requires='>=3.8',
+    author_email="sibirrer@gmail.com",
+    python_requires=">=3.8",
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     description="Hierarchical analysis of strong lensing systems to infer lens properties and cosmological parameters simultaneously",
     install_requires=requirements,
     license="BSD license",
     long_description=readme,
     include_package_data=True,
-    keywords='hierarc',
-    name='hierarc',
+    keywords="hierarc",
+    name="hierarc",
     packages=find_packages(PACKAGE_PATH, "test"),
-    #packages=find_packages(include=['hierarc', 'hierarc.*']),
+    # packages=find_packages(include=['hierarc', 'hierarc.*']),
     setup_requires=setup_requirements,
-    test_suite='test',
+    test_suite="test",
     tests_require=test_requirements,
-    url='https://github.com/sibirrer/hierarc',
-    version='1.1.2',
+    url="https://github.com/sibirrer/hierarc",
+    version="1.1.2",
     zip_safe=False,
-    cmdclass={'test': PyTest}
+    cmdclass={"test": PyTest},
 )

--- a/test/test_Diagnostics/test_blinding.py
+++ b/test/test_Diagnostics/test_blinding.py
@@ -4,10 +4,9 @@ from hierarc.Diagnostics.blinding import blind_posterior
 
 
 def test_blind_posterior():
-    param_names = ['h0', 'lambda_mst', 'test']
+    param_names = ["h0", "lambda_mst", "test"]
     posterior = np.random.random((100, 3))
     posterior_blinded = blind_posterior(posterior=posterior, param_names=param_names)
     assert len(posterior[:, 0]) == 100
     npt.assert_almost_equal(np.median(posterior_blinded[:, 0]), 70, decimal=8)
     npt.assert_almost_equal(np.median(posterior_blinded[:, 1]), 1, decimal=8)
-

--- a/test/test_Diagnostics/test_goodness_of_fit.py
+++ b/test/test_Diagnostics/test_goodness_of_fit.py
@@ -6,12 +6,12 @@ from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 from astropy.cosmology import FlatLambdaCDM
 
 import matplotlib
-matplotlib.use('agg')
+
+matplotlib.use("agg")
 import matplotlib.pyplot as plt
 
 
 class TestGoodnessOfFit(object):
-
     def setup(self):
         np.random.seed(seed=41)
         z_lens = 0.8
@@ -33,79 +33,137 @@ class TestGoodnessOfFit(object):
         kappa_posterior = np.random.normal(loc=0, scale=0.03, size=100000)
         kappa_pdf, kappa_bin_edges = np.histogram(kappa_posterior, density=True)
 
-        likelihood_type_list = ['DdtGaussian',
-                                     'DdtDdKDE',
-                                     'DdtDdGaussian',
-                                     'DsDdsGaussian',
-                                     'DdtLogNorm',
-                                     'IFUKinCov',
-                                     'DdtHist',
-                                     'DdtHistKDE',
-                                     'DdtHistKin',
-                                     'DdtGaussKin']
+        likelihood_type_list = [
+            "DdtGaussian",
+            "DdtDdKDE",
+            "DdtDdGaussian",
+            "DsDdsGaussian",
+            "DdtLogNorm",
+            "IFUKinCov",
+            "DdtHist",
+            "DdtHistKDE",
+            "DdtHistKin",
+            "DdtGaussKin",
+        ]
         self.ifu_index = 5
 
-        self.kwargs_likelihood_list = [{'ddt_mean': ddt, 'ddt_sigma': ddt_sigma},
-                                       {'dd_samples': dd_samples, 'ddt_samples': ddt_samples,
-                                        'kde_type': 'scipy_gaussian', 'bandwidth': 1},
-                                       {'ddt_mean': ddt, 'ddt_sigma': ddt_sigma, 'dd_mean': dd, 'dd_sigma': dd_sigma},
-                                       {'ds_dds_mean': ds_dds, 'ds_dds_sigma': ds_dds_sigma},
-                                       {'ddt_mu': 1, 'ddt_sigma': 0.1},
-                                       {'sigma_v_measurement': [1], 'j_model': [1], 'error_cov_measurement': np.array([[1]]),
-                                        'error_cov_j_sqrt': [[1]]},
-                                       {'ddt_samples': ddt_samples, 'kappa_pdf': kappa_pdf, 'kappa_bin_edges': kappa_bin_edges},
-                                       {'ddt_samples': ddt_samples},
-                                       {'ddt_samples': ddt_samples, 'sigma_v_measurement': [1], 'j_model': [1],
-                                        'error_cov_measurement': [[1]], 'error_cov_j_sqrt': [[1]]},
-                                       {'ddt_mean': 1, 'ddt_sigma': 0.1, 'sigma_v_measurement': [1], 'j_model': [1],
-                                        'error_cov_measurement': [[1]], 'error_cov_j_sqrt': [[1]]},
-                                       ]
+        self.kwargs_likelihood_list = [
+            {"ddt_mean": ddt, "ddt_sigma": ddt_sigma},
+            {
+                "dd_samples": dd_samples,
+                "ddt_samples": ddt_samples,
+                "kde_type": "scipy_gaussian",
+                "bandwidth": 1,
+            },
+            {
+                "ddt_mean": ddt,
+                "ddt_sigma": ddt_sigma,
+                "dd_mean": dd,
+                "dd_sigma": dd_sigma,
+            },
+            {"ds_dds_mean": ds_dds, "ds_dds_sigma": ds_dds_sigma},
+            {"ddt_mu": 1, "ddt_sigma": 0.1},
+            {
+                "sigma_v_measurement": [1],
+                "j_model": [1],
+                "error_cov_measurement": np.array([[1]]),
+                "error_cov_j_sqrt": [[1]],
+            },
+            {
+                "ddt_samples": ddt_samples,
+                "kappa_pdf": kappa_pdf,
+                "kappa_bin_edges": kappa_bin_edges,
+            },
+            {"ddt_samples": ddt_samples},
+            {
+                "ddt_samples": ddt_samples,
+                "sigma_v_measurement": [1],
+                "j_model": [1],
+                "error_cov_measurement": [[1]],
+                "error_cov_j_sqrt": [[1]],
+            },
+            {
+                "ddt_mean": 1,
+                "ddt_sigma": 0.1,
+                "sigma_v_measurement": [1],
+                "j_model": [1],
+                "error_cov_measurement": [[1]],
+                "error_cov_j_sqrt": [[1]],
+            },
+        ]
         for i, likelihood_type in enumerate(likelihood_type_list):
-            self.kwargs_likelihood_list[i]['z_lens'] = z_lens
-            self.kwargs_likelihood_list[i]['z_source'] = z_source
-            self.kwargs_likelihood_list[i]['likelihood_type'] = likelihood_type
+            self.kwargs_likelihood_list[i]["z_lens"] = z_lens
+            self.kwargs_likelihood_list[i]["z_source"] = z_source
+            self.kwargs_likelihood_list[i]["likelihood_type"] = likelihood_type
 
-        self.goodnessofFit = GoodnessOfFit(kwargs_likelihood_list=self.kwargs_likelihood_list)
+        self.goodnessofFit = GoodnessOfFit(
+            kwargs_likelihood_list=self.kwargs_likelihood_list
+        )
 
     def test_plot_ddt_fit(self):
-        kwargs_lens = {'lambda_mst': 1}
+        kwargs_lens = {"lambda_mst": 1}
         kwargs_kin = {}
-        f, ax = self.goodnessofFit.plot_ddt_fit(self.cosmo, kwargs_lens, kwargs_kin, redshift_trend=False)
+        f, ax = self.goodnessofFit.plot_ddt_fit(
+            self.cosmo, kwargs_lens, kwargs_kin, redshift_trend=False
+        )
         plt.close()
-        f, ax = self.goodnessofFit.plot_ddt_fit(self.cosmo, kwargs_lens, kwargs_kin, redshift_trend=True)
+        f, ax = self.goodnessofFit.plot_ddt_fit(
+            self.cosmo, kwargs_lens, kwargs_kin, redshift_trend=True
+        )
         plt.close()
 
     def test_plot_kin_fit(self):
-        kwargs_lens = {'lambda_mst': 1}
+        kwargs_lens = {"lambda_mst": 1}
         kwargs_kin = {}
         f, ax = self.goodnessofFit.plot_kin_fit(self.cosmo, kwargs_lens, kwargs_kin)
         plt.close()
 
     def test_plot_ifu_fit(self):
         f, ax = plt.subplots(1, 1, figsize=(4, 4))
-        kwargs_lens = {'lambda_mst': 1}
+        kwargs_lens = {"lambda_mst": 1}
         kwargs_kin = {}
-        self.goodnessofFit.plot_ifu_fit(ax, self.cosmo, kwargs_lens, kwargs_kin, lens_index=self.ifu_index,
-                                        bin_edges=1., show_legend=True)
+        self.goodnessofFit.plot_ifu_fit(
+            ax,
+            self.cosmo,
+            kwargs_lens,
+            kwargs_kin,
+            lens_index=self.ifu_index,
+            bin_edges=1.0,
+            show_legend=True,
+        )
         plt.close()
 
 
 class TestRaise(unittest.TestCase):
-
     def test_raise(self):
-
         with self.assertRaises(ValueError):
-            kwargs_likelihood_list = [{'ddt_mean': 1, 'ddt_sigma': 0.1, 'z_lens': 0.5, 'z_source': 1.5,
-                                       'likelihood_type': 'DdtGaussian'}]
-            goodness_of_fit = GoodnessOfFit(kwargs_likelihood_list=kwargs_likelihood_list)
+            kwargs_likelihood_list = [
+                {
+                    "ddt_mean": 1,
+                    "ddt_sigma": 0.1,
+                    "z_lens": 0.5,
+                    "z_source": 1.5,
+                    "likelihood_type": "DdtGaussian",
+                }
+            ]
+            goodness_of_fit = GoodnessOfFit(
+                kwargs_likelihood_list=kwargs_likelihood_list
+            )
             f, ax = plt.subplots(1, 1, figsize=(4, 4))
-            kwargs_lens = {'lambda_mst': 1}
+            kwargs_lens = {"lambda_mst": 1}
             kwargs_kin = {}
             cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.0)
-            goodness_of_fit.plot_ifu_fit(ax, cosmo, kwargs_lens, kwargs_kin, lens_index=0, bin_edges=1,
-                                         show_legend=True)
+            goodness_of_fit.plot_ifu_fit(
+                ax,
+                cosmo,
+                kwargs_lens,
+                kwargs_kin,
+                lens_index=0,
+                bin_edges=1,
+                show_legend=True,
+            )
             plt.close()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_LensPosterior/test_anisotropy_config.py
+++ b/test/test_LensPosterior/test_anisotropy_config.py
@@ -4,23 +4,22 @@ import pytest
 
 
 class TestAnisotropyConfig(object):
-
     def setup(self):
         self.r_eff = 2
-        self.config_om = AnisotropyConfig(anisotropy_model='OM', r_eff=self.r_eff)
-        self.config_gom = AnisotropyConfig(anisotropy_model='GOM', r_eff=self.r_eff)
-        self.config_const = AnisotropyConfig(anisotropy_model='const', r_eff=self.r_eff)
+        self.config_om = AnisotropyConfig(anisotropy_model="OM", r_eff=self.r_eff)
+        self.config_gom = AnisotropyConfig(anisotropy_model="GOM", r_eff=self.r_eff)
+        self.config_const = AnisotropyConfig(anisotropy_model="const", r_eff=self.r_eff)
 
     def test_kwargs_anisotropy_base(self):
         kwargs = self.config_om.kwargs_anisotropy_base
-        assert kwargs['r_ani'] == self.r_eff
+        assert kwargs["r_ani"] == self.r_eff
 
         kwargs = self.config_gom.kwargs_anisotropy_base
-        assert kwargs['r_ani'] == self.r_eff
-        assert kwargs['beta_inf'] == 1
+        assert kwargs["r_ani"] == self.r_eff
+        assert kwargs["beta_inf"] == 1
 
         kwargs = self.config_const.kwargs_anisotropy_base
-        assert kwargs['beta'] == 0.1
+        assert kwargs["beta"] == 0.1
 
     def test_ani_param_array(self):
         ani_param_array = self.config_om.ani_param_array
@@ -37,33 +36,31 @@ class TestAnisotropyConfig(object):
         a_ani = 2
         beta_inf = 0.5
         kwargs = self.config_om.anisotropy_kwargs(a_ani)
-        assert kwargs['r_ani'] == a_ani * self.r_eff
+        assert kwargs["r_ani"] == a_ani * self.r_eff
 
         kwargs = self.config_gom.anisotropy_kwargs(a_ani, beta_inf)
-        assert kwargs['r_ani'] == a_ani * self.r_eff
-        assert kwargs['beta_inf'] == beta_inf
+        assert kwargs["r_ani"] == a_ani * self.r_eff
+        assert kwargs["beta_inf"] == beta_inf
 
         kwargs = self.config_const.anisotropy_kwargs(a_ani)
-        assert kwargs['beta'] == a_ani
+        assert kwargs["beta"] == a_ani
 
 
 class TestRaise(unittest.TestCase):
-
     def test_raise(self):
+        with self.assertRaises(ValueError):
+            AnisotropyConfig(anisotropy_model="BAD", r_eff=1)
 
         with self.assertRaises(ValueError):
-            AnisotropyConfig(anisotropy_model='BAD', r_eff=1)
-
-        with self.assertRaises(ValueError):
-            conf = AnisotropyConfig(anisotropy_model='OM', r_eff=1)
-            conf._anisotropy_model = 'BAD'
+            conf = AnisotropyConfig(anisotropy_model="OM", r_eff=1)
+            conf._anisotropy_model = "BAD"
             kwargs = conf.kwargs_anisotropy_base
 
         with self.assertRaises(ValueError):
-            conf = AnisotropyConfig(anisotropy_model='OM', r_eff=1)
-            conf._anisotropy_model = 'BAD'
+            conf = AnisotropyConfig(anisotropy_model="OM", r_eff=1)
+            conf._anisotropy_model = "BAD"
             kwargs = conf.anisotropy_kwargs(a_ani=1, beta_inf=1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_LensPosterior/test_ddt_kin_constraints.py
+++ b/test/test_LensPosterior/test_ddt_kin_constraints.py
@@ -8,21 +8,28 @@ import pytest
 
 
 class TestDdtKinGaussConstraints(object):
-
     def setup(self):
         pass
 
     def test_likelihoodconfiguration_om(self):
-        anisotropy_model = 'OM'
-        kwargs_aperture = {'aperture_type': 'shell', 'r_in': 0, 'r_out': 3 / 2., 'center_ra': 0.0, 'center_dec': 0}
-        kwargs_seeing = {'psf_type': 'GAUSSIAN', 'fwhm': 1.4}
+        anisotropy_model = "OM"
+        kwargs_aperture = {
+            "aperture_type": "shell",
+            "r_in": 0,
+            "r_out": 3 / 2.0,
+            "center_ra": 0.0,
+            "center_dec": 0,
+        }
+        kwargs_seeing = {"psf_type": "GAUSSIAN", "fwhm": 1.4}
 
         # numerical settings (not needed if power-law profiles with Hernquist light distribution is computed)
-        kwargs_numerics_galkin = {'interpol_grid_num': 1000,  # numerical interpolation, should converge -> infinity
-                                  'log_integration': True,
-                                  # log or linear interpolation of surface brightness and mass models
-                                  'max_integrate': 100,
-                                  'min_integrate': 0.001}  # lower/upper bound of numerical integrals
+        kwargs_numerics_galkin = {
+            "interpol_grid_num": 1000,  # numerical interpolation, should converge -> infinity
+            "log_integration": True,
+            # log or linear interpolation of surface brightness and mass models
+            "max_integrate": 100,
+            "min_integrate": 0.001,
+        }  # lower/upper bound of numerical integrals
 
         # redshift
         z_lens = 0.5
@@ -30,53 +37,95 @@ class TestDdtKinGaussConstraints(object):
 
         # lens model
         from astropy.cosmology import FlatLambdaCDM
+
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
 
         lens_cosmo = LensCosmo(z_lens=z_lens, z_source=z_source, cosmo=cosmo)
         ddt_mean = lens_cosmo.ddt
-        ddt_sigma = ddt_mean/50
+        ddt_sigma = ddt_mean / 50
         ddt_samples = np.random.normal(loc=ddt_mean, scale=ddt_sigma, size=50000)
 
-        theta_E = 1.
+        theta_E = 1.0
         r_eff = 1
         gamma = 2.1
 
         # kwargs_model
-        lens_light_model_list = ['HERNQUIST']
-        lens_model_list = ['SPP']
-        kwargs_model = {'lens_model_list': lens_model_list, 'lens_light_model_list': lens_light_model_list}
+        lens_light_model_list = ["HERNQUIST"]
+        lens_model_list = ["SPP"]
+        kwargs_model = {
+            "lens_model_list": lens_model_list,
+            "lens_light_model_list": lens_light_model_list,
+        }
 
         # settings for kinematics calculation with KinematicsAPI of lenstronomy
-        kwargs_kin_api_settings = {'multi_observations': False, 'kwargs_numerics_galkin': kwargs_numerics_galkin,
-                                   'MGE_light': False, 'kwargs_mge_light': None, 'sampling_number': 1000,
-                 'num_kin_sampling': 1000, 'num_psf_sampling': 100}
+        kwargs_kin_api_settings = {
+            "multi_observations": False,
+            "kwargs_numerics_galkin": kwargs_numerics_galkin,
+            "MGE_light": False,
+            "kwargs_mge_light": None,
+            "sampling_number": 1000,
+            "num_kin_sampling": 1000,
+            "num_psf_sampling": 100,
+        }
 
-        kin_api = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_aperture, kwargs_seeing, anisotropy_model,
-                                cosmo=cosmo, **kwargs_kin_api_settings)
+        kin_api = KinematicsAPI(
+            z_lens,
+            z_source,
+            kwargs_model,
+            kwargs_aperture,
+            kwargs_seeing,
+            anisotropy_model,
+            cosmo=cosmo,
+            **kwargs_kin_api_settings
+        )
 
         # compute kinematics with fiducial cosmology
-        kwargs_lens = [{'theta_E': theta_E, 'gamma': gamma, 'center_x': 0, 'center_y': 0}]
-        kwargs_lens_light = [{'Rs': r_eff * 0.551, 'amp': 1.}]
-        kwargs_anisotropy = {'r_ani': r_eff}
-        sigma_v = kin_api.velocity_dispersion(kwargs_lens, kwargs_lens_light, kwargs_anisotropy, r_eff=r_eff,
-                                                      theta_E=theta_E, gamma=gamma, kappa_ext=0)
+        kwargs_lens = [
+            {"theta_E": theta_E, "gamma": gamma, "center_x": 0, "center_y": 0}
+        ]
+        kwargs_lens_light = [{"Rs": r_eff * 0.551, "amp": 1.0}]
+        kwargs_anisotropy = {"r_ani": r_eff}
+        sigma_v = kin_api.velocity_dispersion(
+            kwargs_lens,
+            kwargs_lens_light,
+            kwargs_anisotropy,
+            r_eff=r_eff,
+            theta_E=theta_E,
+            gamma=gamma,
+            kappa_ext=0,
+        )
 
         # compute likelihood
-        kin_constraints = DdtKinConstraints(z_lens=z_lens, z_source=z_source, theta_E=theta_E, theta_E_error=0.01,
-                                            ddt_samples=ddt_samples, ddt_weights=None,
-                                            gamma=gamma, gamma_error=0.02, r_eff=r_eff, r_eff_error=0.05, sigma_v_measured=[sigma_v],
-                                            sigma_v_error_independent=[10], sigma_v_error_covariant=0,
-                                            kwargs_aperture=kwargs_aperture, kwargs_seeing=kwargs_seeing,
-                                            kwargs_lens_light=kwargs_lens_light,
-                                            anisotropy_model=anisotropy_model, **kwargs_kin_api_settings)
+        kin_constraints = DdtKinConstraints(
+            z_lens=z_lens,
+            z_source=z_source,
+            theta_E=theta_E,
+            theta_E_error=0.01,
+            ddt_samples=ddt_samples,
+            ddt_weights=None,
+            gamma=gamma,
+            gamma_error=0.02,
+            r_eff=r_eff,
+            r_eff_error=0.05,
+            sigma_v_measured=[sigma_v],
+            sigma_v_error_independent=[10],
+            sigma_v_error_covariant=0,
+            kwargs_aperture=kwargs_aperture,
+            kwargs_seeing=kwargs_seeing,
+            kwargs_lens_light=kwargs_lens_light,
+            anisotropy_model=anisotropy_model,
+            **kwargs_kin_api_settings
+        )
 
         kwargs_likelihood = kin_constraints.hierarchy_configuration(num_sample_model=5)
-        kwargs_likelihood['normalized'] = False
+        kwargs_likelihood["normalized"] = False
         ln_class = LensLikelihood(**kwargs_likelihood)
-        kwargs_kin = {'a_ani': 1}
-        ln_likelihood = ln_class.lens_log_likelihood(cosmo, kwargs_lens={}, kwargs_kin=kwargs_kin)
+        kwargs_kin = {"a_ani": 1}
+        ln_likelihood = ln_class.lens_log_likelihood(
+            cosmo, kwargs_lens={}, kwargs_kin=kwargs_kin
+        )
         npt.assert_almost_equal(ln_likelihood, 0, decimal=1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_LensPosterior/test_ddt_kin_gauss_constraints.py
+++ b/test/test_LensPosterior/test_ddt_kin_gauss_constraints.py
@@ -8,22 +8,29 @@ import pytest
 
 
 class TestDdtKinGaussConstraints(object):
-
     def setup(self):
         pass
 
     def test_likelihoodconfiguration_om(self):
         np.random.seed(42)
-        anisotropy_model = 'OM'
-        kwargs_aperture = {'aperture_type': 'shell', 'r_in': 0, 'r_out': 3 / 2., 'center_ra': 0.0, 'center_dec': 0}
-        kwargs_seeing = {'psf_type': 'GAUSSIAN', 'fwhm': 1.4}
+        anisotropy_model = "OM"
+        kwargs_aperture = {
+            "aperture_type": "shell",
+            "r_in": 0,
+            "r_out": 3 / 2.0,
+            "center_ra": 0.0,
+            "center_dec": 0,
+        }
+        kwargs_seeing = {"psf_type": "GAUSSIAN", "fwhm": 1.4}
 
         # numerical settings (not needed if power-law profiles with Hernquist light distribution is computed)
-        kwargs_numerics_galkin = {'interpol_grid_num': 1000,  # numerical interpolation, should converge -> infinity
-                                  'log_integration': True,
-                                  # log or linear interpolation of surface brightness and mass models
-                                  'max_integrate': 100,
-                                  'min_integrate': 0.001}  # lower/upper bound of numerical integrals
+        kwargs_numerics_galkin = {
+            "interpol_grid_num": 1000,  # numerical interpolation, should converge -> infinity
+            "log_integration": True,
+            # log or linear interpolation of surface brightness and mass models
+            "max_integrate": 100,
+            "min_integrate": 0.001,
+        }  # lower/upper bound of numerical integrals
 
         # redshift
         z_lens = 0.5
@@ -31,51 +38,92 @@ class TestDdtKinGaussConstraints(object):
 
         # lens model
         from astropy.cosmology import FlatLambdaCDM
+
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
 
         lens_cosmo = LensCosmo(z_lens=z_lens, z_source=z_source, cosmo=cosmo)
         ddt_mean = lens_cosmo.ddt
 
-        theta_E = 1.
+        theta_E = 1.0
         r_eff = 1
         gamma = 2.1
 
         # kwargs_model
-        lens_light_model_list = ['HERNQUIST']
-        lens_model_list = ['SPP']
-        kwargs_model = {'lens_model_list': lens_model_list, 'lens_light_model_list': lens_light_model_list}
+        lens_light_model_list = ["HERNQUIST"]
+        lens_model_list = ["SPP"]
+        kwargs_model = {
+            "lens_model_list": lens_model_list,
+            "lens_light_model_list": lens_light_model_list,
+        }
 
         # settings for kinematics calculation with KinematicsAPI of lenstronomy
-        kwargs_kin_api_settings = {'multi_observations': False, 'kwargs_numerics_galkin': kwargs_numerics_galkin,
-                                   'MGE_light': False, 'kwargs_mge_light': None, 'sampling_number': 1000,
-                 'num_kin_sampling': 1000, 'num_psf_sampling': 100}
+        kwargs_kin_api_settings = {
+            "multi_observations": False,
+            "kwargs_numerics_galkin": kwargs_numerics_galkin,
+            "MGE_light": False,
+            "kwargs_mge_light": None,
+            "sampling_number": 1000,
+            "num_kin_sampling": 1000,
+            "num_psf_sampling": 100,
+        }
 
-        kin_api = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_aperture, kwargs_seeing, anisotropy_model,
-                                cosmo=cosmo, **kwargs_kin_api_settings)
+        kin_api = KinematicsAPI(
+            z_lens,
+            z_source,
+            kwargs_model,
+            kwargs_aperture,
+            kwargs_seeing,
+            anisotropy_model,
+            cosmo=cosmo,
+            **kwargs_kin_api_settings
+        )
 
         # compute kinematics with fiducial cosmology
-        kwargs_lens = [{'theta_E': theta_E, 'gamma': gamma, 'center_x': 0, 'center_y': 0}]
-        kwargs_lens_light = [{'Rs': r_eff * 0.551, 'amp': 1.}]
-        kwargs_anisotropy = {'r_ani': r_eff}
-        sigma_v = kin_api.velocity_dispersion(kwargs_lens, kwargs_lens_light, kwargs_anisotropy, r_eff=r_eff,
-                                                      theta_E=theta_E, gamma=gamma, kappa_ext=0)
+        kwargs_lens = [
+            {"theta_E": theta_E, "gamma": gamma, "center_x": 0, "center_y": 0}
+        ]
+        kwargs_lens_light = [{"Rs": r_eff * 0.551, "amp": 1.0}]
+        kwargs_anisotropy = {"r_ani": r_eff}
+        sigma_v = kin_api.velocity_dispersion(
+            kwargs_lens,
+            kwargs_lens_light,
+            kwargs_anisotropy,
+            r_eff=r_eff,
+            theta_E=theta_E,
+            gamma=gamma,
+            kappa_ext=0,
+        )
 
         # compute likelihood
-        kin_constraints = DdtGaussKinConstraints(z_lens=z_lens, z_source=z_source, theta_E=theta_E, theta_E_error=0.01,
-                                                 ddt_mean=ddt_mean, ddt_sigma=ddt_mean/100,
-                                                 gamma=gamma, gamma_error=0.02, r_eff=r_eff, r_eff_error=0.05, sigma_v_measured=[sigma_v],
-                                                 sigma_v_error_independent=[10], sigma_v_error_covariant=0,
-                                                 kwargs_aperture=kwargs_aperture, kwargs_seeing=kwargs_seeing,
-                                                 anisotropy_model=anisotropy_model, **kwargs_kin_api_settings)
+        kin_constraints = DdtGaussKinConstraints(
+            z_lens=z_lens,
+            z_source=z_source,
+            theta_E=theta_E,
+            theta_E_error=0.01,
+            ddt_mean=ddt_mean,
+            ddt_sigma=ddt_mean / 100,
+            gamma=gamma,
+            gamma_error=0.02,
+            r_eff=r_eff,
+            r_eff_error=0.05,
+            sigma_v_measured=[sigma_v],
+            sigma_v_error_independent=[10],
+            sigma_v_error_covariant=0,
+            kwargs_aperture=kwargs_aperture,
+            kwargs_seeing=kwargs_seeing,
+            anisotropy_model=anisotropy_model,
+            **kwargs_kin_api_settings
+        )
 
         kwargs_likelihood = kin_constraints.hierarchy_configuration(num_sample_model=5)
-        kwargs_likelihood['normalized'] = False
+        kwargs_likelihood["normalized"] = False
         ln_class = LensLikelihood(**kwargs_likelihood)
-        kwargs_kin = {'a_ani': 1}
-        ln_likelihood = ln_class.lens_log_likelihood(cosmo, kwargs_lens={}, kwargs_kin=kwargs_kin)
+        kwargs_kin = {"a_ani": 1}
+        ln_likelihood = ln_class.lens_log_likelihood(
+            cosmo, kwargs_lens={}, kwargs_kin=kwargs_kin
+        )
         npt.assert_almost_equal(ln_likelihood, 0, decimal=1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()
-

--- a/test/test_LensPosterior/test_kin_constraints.py
+++ b/test/test_LensPosterior/test_kin_constraints.py
@@ -7,21 +7,28 @@ import unittest
 
 
 class TestIFUKinPosterior(object):
-
     def setup(self):
         pass
 
     def test_likelihoodconfiguration_om(self):
-        anisotropy_model = 'OM'
-        kwargs_aperture = {'aperture_type': 'shell', 'r_in': 0, 'r_out': 3 / 2., 'center_ra': 0.0, 'center_dec': 0}
-        kwargs_seeing = {'psf_type': 'GAUSSIAN', 'fwhm': 1.4}
+        anisotropy_model = "OM"
+        kwargs_aperture = {
+            "aperture_type": "shell",
+            "r_in": 0,
+            "r_out": 3 / 2.0,
+            "center_ra": 0.0,
+            "center_dec": 0,
+        }
+        kwargs_seeing = {"psf_type": "GAUSSIAN", "fwhm": 1.4}
 
         # numerical settings (not needed if power-law profiles with Hernquist light distribution is computed)
-        kwargs_numerics_galkin = {'interpol_grid_num': 1000,  # numerical interpolation, should converge -> infinity
-                                  'log_integration': True,
-                                  # log or linear interpolation of surface brightness and mass models
-                                  'max_integrate': 100,
-                                  'min_integrate': 0.001}  # lower/upper bound of numerical integrals
+        kwargs_numerics_galkin = {
+            "interpol_grid_num": 1000,  # numerical interpolation, should converge -> infinity
+            "log_integration": True,
+            # log or linear interpolation of surface brightness and mass models
+            "max_integrate": 100,
+            "min_integrate": 0.001,
+        }  # lower/upper bound of numerical integrals
 
         # redshift
         z_lens = 0.5
@@ -29,59 +36,106 @@ class TestIFUKinPosterior(object):
 
         # lens model
         from astropy.cosmology import FlatLambdaCDM
+
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-        theta_E = 1.
+        theta_E = 1.0
         r_eff = 1
         gamma = 2.1
 
         # kwargs_model
-        lens_light_model_list = ['HERNQUIST']
-        lens_model_list = ['SPP']
-        kwargs_model = {'lens_model_list': lens_model_list, 'lens_light_model_list': lens_light_model_list}
+        lens_light_model_list = ["HERNQUIST"]
+        lens_model_list = ["SPP"]
+        kwargs_model = {
+            "lens_model_list": lens_model_list,
+            "lens_light_model_list": lens_light_model_list,
+        }
 
         # settings for kinematics calculation with KinematicsAPI of lenstronomy
-        kwargs_kin_api_settings = {'multi_observations': False, 'kwargs_numerics_galkin': kwargs_numerics_galkin,
-                                   'MGE_light': False, 'kwargs_mge_light': None, 'sampling_number': 1000,
-                 'num_kin_sampling': 1000, 'num_psf_sampling': 100}
+        kwargs_kin_api_settings = {
+            "multi_observations": False,
+            "kwargs_numerics_galkin": kwargs_numerics_galkin,
+            "MGE_light": False,
+            "kwargs_mge_light": None,
+            "sampling_number": 1000,
+            "num_kin_sampling": 1000,
+            "num_psf_sampling": 100,
+        }
 
-        kin_api = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_aperture, kwargs_seeing, anisotropy_model,
-                                cosmo=cosmo, **kwargs_kin_api_settings)
+        kin_api = KinematicsAPI(
+            z_lens,
+            z_source,
+            kwargs_model,
+            kwargs_aperture,
+            kwargs_seeing,
+            anisotropy_model,
+            cosmo=cosmo,
+            **kwargs_kin_api_settings
+        )
 
         # compute kinematics with fiducial cosmology
-        kwargs_lens = [{'theta_E': theta_E, 'gamma': gamma, 'center_x': 0, 'center_y': 0}]
-        kwargs_lens_light = [{'Rs': r_eff * 0.551, 'amp': 1.}]
-        kwargs_anisotropy = {'r_ani': r_eff}
-        sigma_v = kin_api.velocity_dispersion(kwargs_lens, kwargs_lens_light, kwargs_anisotropy, r_eff=r_eff,
-                                                      theta_E=theta_E, gamma=gamma, kappa_ext=0)
+        kwargs_lens = [
+            {"theta_E": theta_E, "gamma": gamma, "center_x": 0, "center_y": 0}
+        ]
+        kwargs_lens_light = [{"Rs": r_eff * 0.551, "amp": 1.0}]
+        kwargs_anisotropy = {"r_ani": r_eff}
+        sigma_v = kin_api.velocity_dispersion(
+            kwargs_lens,
+            kwargs_lens_light,
+            kwargs_anisotropy,
+            r_eff=r_eff,
+            theta_E=theta_E,
+            gamma=gamma,
+            kappa_ext=0,
+        )
 
         # compute likelihood
-        kin_constraints = KinConstraints(z_lens=z_lens, z_source=z_source, theta_E=theta_E, theta_E_error=0.01,
-                                         gamma=gamma, gamma_error=0.02, r_eff=r_eff, r_eff_error=0.05,
-                                         sigma_v_measured=[sigma_v],
-                                         sigma_v_error_independent=[10], sigma_v_error_cov_matrix=[[100]],
-                                         sigma_v_error_covariant=0,
-                                         kwargs_aperture=kwargs_aperture, kwargs_seeing=kwargs_seeing,
-                                         anisotropy_model=anisotropy_model, **kwargs_kin_api_settings)
+        kin_constraints = KinConstraints(
+            z_lens=z_lens,
+            z_source=z_source,
+            theta_E=theta_E,
+            theta_E_error=0.01,
+            gamma=gamma,
+            gamma_error=0.02,
+            r_eff=r_eff,
+            r_eff_error=0.05,
+            sigma_v_measured=[sigma_v],
+            sigma_v_error_independent=[10],
+            sigma_v_error_cov_matrix=[[100]],
+            sigma_v_error_covariant=0,
+            kwargs_aperture=kwargs_aperture,
+            kwargs_seeing=kwargs_seeing,
+            anisotropy_model=anisotropy_model,
+            **kwargs_kin_api_settings
+        )
 
         kwargs_likelihood = kin_constraints.hierarchy_configuration(num_sample_model=5)
-        kwargs_likelihood['normalized'] = False
+        kwargs_likelihood["normalized"] = False
         ln_class = LensLikelihood(**kwargs_likelihood)
-        kwargs_kin = {'a_ani': 1}
-        ln_likelihood = ln_class.lens_log_likelihood(cosmo, kwargs_lens={}, kwargs_kin=kwargs_kin)
+        kwargs_kin = {"a_ani": 1}
+        ln_likelihood = ln_class.lens_log_likelihood(
+            cosmo, kwargs_lens={}, kwargs_kin=kwargs_kin
+        )
         npt.assert_almost_equal(ln_likelihood, 0, decimal=1)
 
-
     def test_likelihoodconfiguration_gom(self):
-        anisotropy_model = 'GOM'
-        kwargs_aperture = {'aperture_type': 'shell', 'r_in': 0, 'r_out': 3 / 2., 'center_ra': 0.0, 'center_dec': 0}
-        kwargs_seeing = {'psf_type': 'GAUSSIAN', 'fwhm': 1.4}
+        anisotropy_model = "GOM"
+        kwargs_aperture = {
+            "aperture_type": "shell",
+            "r_in": 0,
+            "r_out": 3 / 2.0,
+            "center_ra": 0.0,
+            "center_dec": 0,
+        }
+        kwargs_seeing = {"psf_type": "GAUSSIAN", "fwhm": 1.4}
 
         # numerical settings (not needed if power-law profiles with Hernquist light distribution is computed)
-        kwargs_numerics_galkin = {'interpol_grid_num': 1000,  # numerical interpolation, should converge -> infinity
-                                  'log_integration': True,
-                                  # log or linear interpolation of surface brightness and mass models
-                                  'max_integrate': 100,
-                                  'min_integrate': 0.001}  # lower/upper bound of numerical integrals
+        kwargs_numerics_galkin = {
+            "interpol_grid_num": 1000,  # numerical interpolation, should converge -> infinity
+            "log_integration": True,
+            # log or linear interpolation of surface brightness and mass models
+            "max_integrate": 100,
+            "min_integrate": 0.001,
+        }  # lower/upper bound of numerical integrals
 
         # redshift
         z_lens = 0.5
@@ -89,83 +143,147 @@ class TestIFUKinPosterior(object):
 
         # lens model
         from astropy.cosmology import FlatLambdaCDM
+
         cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
-        theta_E = 1.
+        theta_E = 1.0
         r_eff = 1
         gamma = 2.1
 
         # kwargs_model
-        lens_light_model_list = ['HERNQUIST']
-        lens_model_list = ['SPP']
-        kwargs_model = {'lens_model_list': lens_model_list, 'lens_light_model_list': lens_light_model_list}
+        lens_light_model_list = ["HERNQUIST"]
+        lens_model_list = ["SPP"]
+        kwargs_model = {
+            "lens_model_list": lens_model_list,
+            "lens_light_model_list": lens_light_model_list,
+        }
 
         # settings for kinematics calculation with KinematicsAPI of lenstronomy
-        kwargs_kin_api_settings = {'multi_observations': False, 'kwargs_numerics_galkin': kwargs_numerics_galkin,
-                                   'MGE_light': False, 'kwargs_mge_light': None, 'sampling_number': 1000,
-                 'num_kin_sampling': 1000, 'num_psf_sampling': 100}
+        kwargs_kin_api_settings = {
+            "multi_observations": False,
+            "kwargs_numerics_galkin": kwargs_numerics_galkin,
+            "MGE_light": False,
+            "kwargs_mge_light": None,
+            "sampling_number": 1000,
+            "num_kin_sampling": 1000,
+            "num_psf_sampling": 100,
+        }
 
-        kin_api = KinematicsAPI(z_lens, z_source, kwargs_model, kwargs_aperture, kwargs_seeing, anisotropy_model,
-                                cosmo=cosmo, **kwargs_kin_api_settings)
+        kin_api = KinematicsAPI(
+            z_lens,
+            z_source,
+            kwargs_model,
+            kwargs_aperture,
+            kwargs_seeing,
+            anisotropy_model,
+            cosmo=cosmo,
+            **kwargs_kin_api_settings
+        )
 
         # compute kinematics with fiducial cosmology
-        kwargs_lens = [{'theta_E': theta_E, 'gamma': gamma, 'center_x': 0, 'center_y': 0}]
-        kwargs_lens_light = [{'Rs': r_eff * 0.551, 'amp': 1.}]
+        kwargs_lens = [
+            {"theta_E": theta_E, "gamma": gamma, "center_x": 0, "center_y": 0}
+        ]
+        kwargs_lens_light = [{"Rs": r_eff * 0.551, "amp": 1.0}]
         beta_inf = 0.5
-        kwargs_anisotropy = {'r_ani': r_eff, 'beta_inf': beta_inf}
-        sigma_v = kin_api.velocity_dispersion(kwargs_lens, kwargs_lens_light, kwargs_anisotropy, r_eff=r_eff,
-                                                      theta_E=theta_E, gamma=gamma, kappa_ext=0)
+        kwargs_anisotropy = {"r_ani": r_eff, "beta_inf": beta_inf}
+        sigma_v = kin_api.velocity_dispersion(
+            kwargs_lens,
+            kwargs_lens_light,
+            kwargs_anisotropy,
+            r_eff=r_eff,
+            theta_E=theta_E,
+            gamma=gamma,
+            kappa_ext=0,
+        )
 
         # compute likelihood
-        kin_constraints = KinConstraints(z_lens=z_lens, z_source=z_source, theta_E=theta_E, theta_E_error=0.01,
-                                         gamma=gamma, gamma_error=0.02, r_eff=r_eff, r_eff_error=0.05, sigma_v_measured=[sigma_v],
-                                         sigma_v_error_independent=[10], sigma_v_error_covariant=0,
-                                         kwargs_aperture=kwargs_aperture, kwargs_seeing=kwargs_seeing,
-                                         anisotropy_model=anisotropy_model, **kwargs_kin_api_settings)
+        kin_constraints = KinConstraints(
+            z_lens=z_lens,
+            z_source=z_source,
+            theta_E=theta_E,
+            theta_E_error=0.01,
+            gamma=gamma,
+            gamma_error=0.02,
+            r_eff=r_eff,
+            r_eff_error=0.05,
+            sigma_v_measured=[sigma_v],
+            sigma_v_error_independent=[10],
+            sigma_v_error_covariant=0,
+            kwargs_aperture=kwargs_aperture,
+            kwargs_seeing=kwargs_seeing,
+            anisotropy_model=anisotropy_model,
+            **kwargs_kin_api_settings
+        )
 
         kwargs_likelihood = kin_constraints.hierarchy_configuration(num_sample_model=5)
-        kwargs_likelihood['normalized'] = False
+        kwargs_likelihood["normalized"] = False
         ln_class = LensLikelihood(**kwargs_likelihood)
-        kwargs_kin = {'a_ani': 1, 'beta_inf': beta_inf}
-        ln_likelihood = ln_class.lens_log_likelihood(cosmo, kwargs_lens={}, kwargs_kin=kwargs_kin)
+        kwargs_kin = {"a_ani": 1, "beta_inf": beta_inf}
+        ln_likelihood = ln_class.lens_log_likelihood(
+            cosmo, kwargs_lens={}, kwargs_kin=kwargs_kin
+        )
         npt.assert_almost_equal(ln_likelihood, 0, decimal=1)
 
 
 class TestRaise(unittest.TestCase):
-
     def test_raise(self):
-
         with self.assertRaises(ValueError):
-            anisotropy_model = 'GOM'
-            kwargs_aperture = {'aperture_type': 'shell', 'r_in': 0, 'r_out': 3 / 2., 'center_ra': 0.0, 'center_dec': 0}
-            kwargs_seeing = {'psf_type': 'GAUSSIAN', 'fwhm': 1.4}
+            anisotropy_model = "GOM"
+            kwargs_aperture = {
+                "aperture_type": "shell",
+                "r_in": 0,
+                "r_out": 3 / 2.0,
+                "center_ra": 0.0,
+                "center_dec": 0,
+            }
+            kwargs_seeing = {"psf_type": "GAUSSIAN", "fwhm": 1.4}
 
             # numerical settings (not needed if power-law profiles with Hernquist light distribution is computed)
-            kwargs_numerics_galkin = {'interpol_grid_num': 1000,  # numerical interpolation, should converge -> infinity
-                                      'log_integration': True,
-                                      # log or linear interpolation of surface brightness and mass models
-                                      'max_integrate': 100,
-                                      'min_integrate': 0.001}  # lower/upper bound of numerical integrals
+            kwargs_numerics_galkin = {
+                "interpol_grid_num": 1000,  # numerical interpolation, should converge -> infinity
+                "log_integration": True,
+                # log or linear interpolation of surface brightness and mass models
+                "max_integrate": 100,
+                "min_integrate": 0.001,
+            }  # lower/upper bound of numerical integrals
 
             # redshift
             z_lens = 0.5
             z_source = 1.5
-            theta_E = 1.
+            theta_E = 1.0
             r_eff = 1
             gamma = 2.1
 
             # settings for kinematics calculation with KinematicsAPI of lenstronomy
-            kwargs_kin_api_settings = {'multi_observations': False, 'kwargs_numerics_galkin': kwargs_numerics_galkin,
-                                       'MGE_light': False, 'kwargs_mge_light': None, 'sampling_number': 1000,
-                                       'num_kin_sampling': 1000, 'num_psf_sampling': 100}
-            kin_constraints = KinConstraints(z_lens=z_lens, z_source=z_source, theta_E=theta_E, theta_E_error=0.01,
-                                             gamma=gamma, gamma_error=0.02, r_eff=r_eff, r_eff_error=0.05,
-                                             sigma_v_measured=[200],
-                                             sigma_v_error_independent=[10], sigma_v_error_covariant=0,
-                                             kwargs_aperture=kwargs_aperture, kwargs_seeing=kwargs_seeing,
-                                             anisotropy_model=anisotropy_model, **kwargs_kin_api_settings)
-            kin_constraints._anisotropy_model = 'BAD'
+            kwargs_kin_api_settings = {
+                "multi_observations": False,
+                "kwargs_numerics_galkin": kwargs_numerics_galkin,
+                "MGE_light": False,
+                "kwargs_mge_light": None,
+                "sampling_number": 1000,
+                "num_kin_sampling": 1000,
+                "num_psf_sampling": 100,
+            }
+            kin_constraints = KinConstraints(
+                z_lens=z_lens,
+                z_source=z_source,
+                theta_E=theta_E,
+                theta_E_error=0.01,
+                gamma=gamma,
+                gamma_error=0.02,
+                r_eff=r_eff,
+                r_eff_error=0.05,
+                sigma_v_measured=[200],
+                sigma_v_error_independent=[10],
+                sigma_v_error_covariant=0,
+                kwargs_aperture=kwargs_aperture,
+                kwargs_seeing=kwargs_seeing,
+                anisotropy_model=anisotropy_model,
+                **kwargs_kin_api_settings
+            )
+            kin_constraints._anisotropy_model = "BAD"
             kin_constraints._anisotropy_scaling_relative(j_ani_0=1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_KDELikelihood/test_KDE_likelihood.py
+++ b/test/test_Likelihood/test_KDELikelihood/test_KDE_likelihood.py
@@ -4,18 +4,29 @@ import unittest
 import numpy as np
 import pytest
 
-from hierarc.Likelihood.KDELikelihood.chain import import_Planck_chain, rescale_vector_to_unity, \
-    rescale_vector_from_unity
-from hierarc.Likelihood.KDELikelihood.kde_likelihood import _PATH_2_PLANCKDATA, KDELikelihood
+from hierarc.Likelihood.KDELikelihood.chain import (
+    import_Planck_chain,
+    rescale_vector_to_unity,
+    rescale_vector_from_unity,
+)
+from hierarc.Likelihood.KDELikelihood.kde_likelihood import (
+    _PATH_2_PLANCKDATA,
+    KDELikelihood,
+)
 
 
 class TestKDELikelihood(object):
-
     def setup(self):
-        self.cosmo_params = ['h0', 'om']
-        self.cosmology = 'FLCDM'
-        self.chain = import_Planck_chain(_PATH_2_PLANCKDATA, 'base', 'plikHM_TTTEEE_lowl_lowE', self.cosmo_params,
-                                         self.cosmology, rescale=True)
+        self.cosmo_params = ["h0", "om"]
+        self.cosmology = "FLCDM"
+        self.chain = import_Planck_chain(
+            _PATH_2_PLANCKDATA,
+            "base",
+            "plikHM_TTTEEE_lowl_lowE",
+            self.cosmo_params,
+            self.cosmology,
+            rescale=True,
+        )
         print(self.chain)
 
     def test_full_likelihood(self):
@@ -43,25 +54,34 @@ class TestKDELikelihood(object):
         samples = np.asarray([samples[k] for k in self.cosmo_params])
         samples_copy = copy.deepcopy(samples)
 
-        samples = rescale_vector_from_unity(samples, self.chain.rescale_dic, self.cosmo_params)
-        samples = rescale_vector_to_unity(samples, self.chain.rescale_dic, self.cosmo_params)
+        samples = rescale_vector_from_unity(
+            samples, self.chain.rescale_dic, self.cosmo_params
+        )
+        samples = rescale_vector_to_unity(
+            samples, self.chain.rescale_dic, self.cosmo_params
+        )
 
         assert samples == pytest.approx(samples_copy, rel=1e-6)
 
-        self.chain.create_param('w0')
-        self.chain.fill_default('w0', -1.0, verbose=True)
+        self.chain.create_param("w0")
+        self.chain.fill_default("w0", -1.0, verbose=True)
 
-        wa = np.ones_like(self.chain.params['h0'])
-        self.chain.fill_default_array('wa', wa, verbose=True)
+        wa = np.ones_like(self.chain.params["h0"])
+        self.chain.fill_default_array("wa", wa, verbose=True)
 
 
 class TestRaise(unittest.TestCase):
-
     def test_raise(self):
-        cosmo_params = ['h0', 'om']
-        cosmology = 'FLCDM'
-        chain = import_Planck_chain(_PATH_2_PLANCKDATA, 'base', 'plikHM_TTTEEE_lowl_lowE', cosmo_params,
-                                         cosmology, rescale=True)
+        cosmo_params = ["h0", "om"]
+        cosmology = "FLCDM"
+        chain = import_Planck_chain(
+            _PATH_2_PLANCKDATA,
+            "base",
+            "plikHM_TTTEEE_lowl_lowE",
+            cosmo_params,
+            cosmology,
+            rescale=True,
+        )
 
         with self.assertRaises(RuntimeError):
             chain.rescale_to_unity()
@@ -73,5 +93,6 @@ class TestRaise(unittest.TestCase):
         with self.assertRaises(NameError):
             kdelikelihood = KDELikelihood(chain, likelihood_type="BAD")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_base_lens_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_base_lens_likelihood.py
@@ -5,7 +5,6 @@ from hierarc.Likelihood.LensLikelihood.base_lens_likelihood import LensLikelihoo
 
 
 class TestLensLikelihood(object):
-
     def setup(self):
         np.random.seed(seed=41)
         self.z_lens = 0.8
@@ -14,54 +13,107 @@ class TestLensLikelihood(object):
         ddt_samples = np.random.normal(1, 0.1, num_samples)
         dd_samples = np.random.normal(1, 0.1, num_samples)
 
-        self.likelihood_type_list = ['DdtGaussian',
-                                'DdtDdKDE',
-                                'DdtDdGaussian',
-                                'DsDdsGaussian',
-                                'DdtLogNorm',
-                                'IFUKinCov',
-                                'DdtHist',
-                                'DdtHistKDE',
-                                'DdtHistKin',
-                                'DdtGaussKin',
-                                     'Mag',
-                                     'TDMag',
-                                     'TDMagMagnitude']
+        self.likelihood_type_list = [
+            "DdtGaussian",
+            "DdtDdKDE",
+            "DdtDdGaussian",
+            "DsDdsGaussian",
+            "DdtLogNorm",
+            "IFUKinCov",
+            "DdtHist",
+            "DdtHistKDE",
+            "DdtHistKin",
+            "DdtGaussKin",
+            "Mag",
+            "TDMag",
+            "TDMagMagnitude",
+        ]
 
-        self.kwargs_likelihood_list = [{'ddt_mean': 1, 'ddt_sigma': 0.1},
-                                  {'dd_samples': dd_samples, 'ddt_samples': ddt_samples, 'kde_type': 'scipy_gaussian', 'bandwidth': 1},
-                                  {'ddt_mean': 1, 'ddt_sigma': 0.1, 'dd_mean': 1, 'dd_sigma': 0.1},
-                                  {'ds_dds_mean': 1, 'ds_dds_sigma': 0.1},
-                                  {'ddt_mu': 1, 'ddt_sigma': 0.1},
-                                  {'sigma_v_measurement': [1], 'j_model': [1], 'error_cov_measurement': [[1]], 'error_cov_j_sqrt': [[1]]},
-                                  {'ddt_samples': ddt_samples},
-                                  {'ddt_samples': ddt_samples},
-                                  {'ddt_samples': ddt_samples, 'sigma_v_measurement': [1], 'j_model': [1], 'error_cov_measurement': [[1]], 'error_cov_j_sqrt': [[1]]},
-                                  {'ddt_mean': 1, 'ddt_sigma': 0.1, 'sigma_v_measurement': [1], 'j_model': [1], 'error_cov_measurement': [[1]], 'error_cov_j_sqrt': [[1]]},
-                                       {'amp_measured': [1.], 'cov_amp_measured': [[1.]], 'magnification_model': [1.], 'cov_magnification_model': [[1.]], 'magnitude_zero_point': 20.},
-                                       {'time_delay_measured': [1.], 'cov_td_measured': [[1.]], 'amp_measured': [1., 1.],
-                                        'cov_amp_measured': [[1., 0], [0, 1.]], 'fermat_diff': [1.], 'magnification_model': [1., 1.],
-                                        'cov_model': np.ones((3, 3)), 'magnitude_zero_point': 20.},
-                                       {'time_delay_measured': [1.], 'cov_td_measured': [[1.]],
-                                        'magnitude_measured': [1., 1.],
-                                        'cov_magnitude_measured': [[1., 0], [0, 1.]], 'fermat_diff': [1.],
-                                        'magnification_model': [1., 1.],
-                                        'cov_model': np.ones((3, 3))}
-                                  ]
+        self.kwargs_likelihood_list = [
+            {"ddt_mean": 1, "ddt_sigma": 0.1},
+            {
+                "dd_samples": dd_samples,
+                "ddt_samples": ddt_samples,
+                "kde_type": "scipy_gaussian",
+                "bandwidth": 1,
+            },
+            {"ddt_mean": 1, "ddt_sigma": 0.1, "dd_mean": 1, "dd_sigma": 0.1},
+            {"ds_dds_mean": 1, "ds_dds_sigma": 0.1},
+            {"ddt_mu": 1, "ddt_sigma": 0.1},
+            {
+                "sigma_v_measurement": [1],
+                "j_model": [1],
+                "error_cov_measurement": [[1]],
+                "error_cov_j_sqrt": [[1]],
+            },
+            {"ddt_samples": ddt_samples},
+            {"ddt_samples": ddt_samples},
+            {
+                "ddt_samples": ddt_samples,
+                "sigma_v_measurement": [1],
+                "j_model": [1],
+                "error_cov_measurement": [[1]],
+                "error_cov_j_sqrt": [[1]],
+            },
+            {
+                "ddt_mean": 1,
+                "ddt_sigma": 0.1,
+                "sigma_v_measurement": [1],
+                "j_model": [1],
+                "error_cov_measurement": [[1]],
+                "error_cov_j_sqrt": [[1]],
+            },
+            {
+                "amp_measured": [1.0],
+                "cov_amp_measured": [[1.0]],
+                "magnification_model": [1.0],
+                "cov_magnification_model": [[1.0]],
+                "magnitude_zero_point": 20.0,
+            },
+            {
+                "time_delay_measured": [1.0],
+                "cov_td_measured": [[1.0]],
+                "amp_measured": [1.0, 1.0],
+                "cov_amp_measured": [[1.0, 0], [0, 1.0]],
+                "fermat_diff": [1.0],
+                "magnification_model": [1.0, 1.0],
+                "cov_model": np.ones((3, 3)),
+                "magnitude_zero_point": 20.0,
+            },
+            {
+                "time_delay_measured": [1.0],
+                "cov_td_measured": [[1.0]],
+                "magnitude_measured": [1.0, 1.0],
+                "cov_magnitude_measured": [[1.0, 0], [0, 1.0]],
+                "fermat_diff": [1.0],
+                "magnification_model": [1.0, 1.0],
+                "cov_model": np.ones((3, 3)),
+            },
+        ]
 
     def test_log_likelihood(self):
         for i, likelihood_type in enumerate(self.likelihood_type_list):
-            likelihood = LensLikelihoodBase(z_lens=self.z_lens, z_source=self.z_source, likelihood_type=likelihood_type,
-                               **self.kwargs_likelihood_list[i])
+            likelihood = LensLikelihoodBase(
+                z_lens=self.z_lens,
+                z_source=self.z_source,
+                likelihood_type=likelihood_type,
+                **self.kwargs_likelihood_list[i]
+            )
             print(likelihood_type)
-            logl = likelihood.log_likelihood(ddt=1, dd=1, aniso_scaling=None, sigma_v_sys_error=1, mu_intrinsic=1)
+            logl = likelihood.log_likelihood(
+                ddt=1, dd=1, aniso_scaling=None, sigma_v_sys_error=1, mu_intrinsic=1
+            )
             print(logl)
             assert logl > -np.inf
 
     def test_predictions_measurements(self):
         for i, likelihood_type in enumerate(self.likelihood_type_list):
-            likelihood = LensLikelihoodBase(z_lens=self.z_lens, z_source=self.z_source, likelihood_type=likelihood_type,
-                               **self.kwargs_likelihood_list[i])
+            likelihood = LensLikelihoodBase(
+                z_lens=self.z_lens,
+                z_source=self.z_source,
+                likelihood_type=likelihood_type,
+                **self.kwargs_likelihood_list[i]
+            )
             ddt_measurement = likelihood.ddt_measurement()
             likelihood.sigma_v_measurement(sigma_v_sys_error=0)
             likelihood.sigma_v_prediction(ddt=1, dd=1, aniso_scaling=1)
@@ -69,17 +121,19 @@ class TestLensLikelihood(object):
 
 
 class TestRaise(unittest.TestCase):
-
     def test_raise(self):
-
         with self.assertRaises(ValueError):
-            LensLikelihoodBase(z_lens=0.5, z_source=2, likelihood_type='BAD')
+            LensLikelihoodBase(z_lens=0.5, z_source=2, likelihood_type="BAD")
         with self.assertRaises(ValueError):
-            likelihood = LensLikelihoodBase(z_lens=0.5, z_source=2, likelihood_type='DdtGaussian',
-                                            **{'ddt_mean': 1, 'ddt_sigma': 0.1})
-            likelihood.likelihood_type = 'BAD'
+            likelihood = LensLikelihoodBase(
+                z_lens=0.5,
+                z_source=2,
+                likelihood_type="DdtGaussian",
+                **{"ddt_mean": 1, "ddt_sigma": 0.1}
+            )
+            likelihood.likelihood_type = "BAD"
             likelihood.log_likelihood(ddt=1, dd=1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_ddt_dd_gauss_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_ddt_dd_gauss_likelihood.py
@@ -5,7 +5,6 @@ import pytest
 
 
 class TestDdtDdGaussianLikelihood(object):
-
     def setup(self):
         np.random.seed(seed=41)
         self.z_lens = 0.8
@@ -17,20 +16,29 @@ class TestDdtDdGaussianLikelihood(object):
         self.dd_mean = 1
         self.dd_sigma = 0.1
 
-        self.kwargs_lens = {'z_lens': self.z_lens, 'z_source': self.z_source,
-                            'ddt_mean': self.ddt_mean, 'ddt_sigma': self.ddt_sigma,
-                            'dd_mean': self.dd_mean, 'dd_sigma': self.dd_sigma}
+        self.kwargs_lens = {
+            "z_lens": self.z_lens,
+            "z_source": self.z_source,
+            "ddt_mean": self.ddt_mean,
+            "ddt_sigma": self.ddt_sigma,
+            "dd_mean": self.dd_mean,
+            "dd_sigma": self.dd_sigma,
+        }
 
     def test_log_likelihood(self):
         likelihood = DdtDdGaussian(**self.kwargs_lens)
         lnlog = likelihood.log_likelihood(ddt=self.ddt_mean, dd=self.dd_mean)
         npt.assert_almost_equal(lnlog, 0, decimal=5)
 
-        lnlog = likelihood.log_likelihood(ddt=self.ddt_mean + self.ddt_sigma, dd=self.dd_mean)
+        lnlog = likelihood.log_likelihood(
+            ddt=self.ddt_mean + self.ddt_sigma, dd=self.dd_mean
+        )
         npt.assert_almost_equal(lnlog, -0.5, decimal=5)
 
-        aniso_scaling = [1 + self.dd_sigma/self.dd_mean]
-        lnlog = likelihood.log_likelihood(ddt=self.ddt_mean, dd=self.dd_mean, aniso_scaling=aniso_scaling)
+        aniso_scaling = [1 + self.dd_sigma / self.dd_mean]
+        lnlog = likelihood.log_likelihood(
+            ddt=self.ddt_mean, dd=self.dd_mean, aniso_scaling=aniso_scaling
+        )
         npt.assert_almost_equal(lnlog, -0.5, decimal=5)
 
     def test_ddt_measurement(self):
@@ -40,5 +48,5 @@ class TestDdtDdGaussianLikelihood(object):
         assert ddt_sigma == self.ddt_sigma
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_ddt_dd_kde_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_ddt_dd_kde_likelihood.py
@@ -8,7 +8,6 @@ from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 
 
 class TestDdtDdKDELikelihood(object):
-
     def setup(self):
         np.random.seed(seed=41)
         self.z_L = 0.8
@@ -24,28 +23,41 @@ class TestDdtDdKDELikelihood(object):
         self.sigma_Dd = 100
         self.sigma_Ddt = 500
         num_samples = 10000
-        self.D_dt_samples = np.random.normal(self.D_dt_true, self.sigma_Ddt, num_samples)
+        self.D_dt_samples = np.random.normal(
+            self.D_dt_true, self.sigma_Ddt, num_samples
+        )
         self.D_d_samples = np.random.normal(self.Dd_true, self.sigma_Dd, num_samples)
 
-        self.kwargs_lens = {'z_lens': self.z_L, 'z_source': self.z_S,
-                                  'dd_samples': self.D_d_samples, 'ddt_samples': self.D_dt_samples,
-                                  'kde_type': 'scipy_gaussian', 'bandwidth': 1}
+        self.kwargs_lens = {
+            "z_lens": self.z_L,
+            "z_source": self.z_S,
+            "dd_samples": self.D_d_samples,
+            "ddt_samples": self.D_dt_samples,
+            "kde_type": "scipy_gaussian",
+            "bandwidth": 1,
+        }
 
     def test_log_likelihood(self):
         tdkin = DdtDdKDELikelihood(**self.kwargs_lens)
         kwargs_lens = copy.deepcopy(self.kwargs_lens)
-        kwargs_lens['interpol'] = True
+        kwargs_lens["interpol"] = True
         tdkin_interp = DdtDdKDELikelihood(**kwargs_lens)
 
         delta_ddt = 1
         delta_dd = 200
-        logl = tdkin.log_likelihood(ddt=self.D_dt_true+delta_ddt, dd=self.Dd_true+delta_dd)
-        logl_interp = tdkin_interp.log_likelihood(ddt=self.D_dt_true+delta_ddt, dd=self.Dd_true+delta_dd)
+        logl = tdkin.log_likelihood(
+            ddt=self.D_dt_true + delta_ddt, dd=self.Dd_true + delta_dd
+        )
+        logl_interp = tdkin_interp.log_likelihood(
+            ddt=self.D_dt_true + delta_ddt, dd=self.Dd_true + delta_dd
+        )
         print(logl, logl_interp)
         npt.assert_almost_equal(logl, logl_interp, decimal=3)
-        logl_interp = tdkin_interp.log_likelihood(ddt=self.D_dt_true + 100000, dd=self.Dd_true+100000)
-        #assert logl_interp == -np.inf
+        logl_interp = tdkin_interp.log_likelihood(
+            ddt=self.D_dt_true + 100000, dd=self.Dd_true + 100000
+        )
+        # assert logl_interp == -np.inf
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_ddt_gauss_kin_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_ddt_gauss_kin_likelihood.py
@@ -1,6 +1,8 @@
 from hierarc.Likelihood.LensLikelihood.ddt_gauss_likelihood import DdtGaussianLikelihood
 from hierarc.Likelihood.LensLikelihood.kin_likelihood import KinLikelihood
-from hierarc.Likelihood.LensLikelihood.ddt_gauss_kin_likelihood import DdtGaussKinLikelihood
+from hierarc.Likelihood.LensLikelihood.ddt_gauss_kin_likelihood import (
+    DdtGaussKinLikelihood,
+)
 import numpy as np
 import numpy.testing as npt
 from lenstronomy.Util import constants as const
@@ -8,7 +10,6 @@ import pytest
 
 
 class TestDdtGaussKinLikelihood(object):
-
     def setup(self):
         self.z_lens = 0.8
         self.z_source = 3.0
@@ -16,33 +17,58 @@ class TestDdtGaussKinLikelihood(object):
         self.ddt_mean = 10
         self.ddt_sigma = 0.1
 
-        self.dd_mean = 1.
+        self.dd_mean = 1.0
 
-        kwargs_ddt_gauss = {'z_lens': self.z_lens, 'z_source': self.z_source,
-                            'ddt_mean': self.ddt_mean, 'ddt_sigma': self.ddt_sigma}
+        kwargs_ddt_gauss = {
+            "z_lens": self.z_lens,
+            "z_source": self.z_source,
+            "ddt_mean": self.ddt_mean,
+            "ddt_sigma": self.ddt_sigma,
+        }
 
         ds_dds = self.ddt_mean / self.dd_mean / (1 + self.z_lens)
         j_mean_list = np.ones(1)
         scaling_ifu = 1
-        sigma_v_measurement = np.sqrt(ds_dds * scaling_ifu * j_mean_list) * const.c / 1000
-        sigma_v_sigma = sigma_v_measurement / 10.
-        error_cov_measurement = np.diag(sigma_v_sigma ** 2)
+        sigma_v_measurement = (
+            np.sqrt(ds_dds * scaling_ifu * j_mean_list) * const.c / 1000
+        )
+        sigma_v_sigma = sigma_v_measurement / 10.0
+        error_cov_measurement = np.diag(sigma_v_sigma**2)
         error_cov_j_sqrt = np.diag(np.zeros_like(sigma_v_measurement))
-        self.kin_likelihood = KinLikelihood(self.z_lens, self.z_source, sigma_v_measurement, j_mean_list,
-                                            error_cov_measurement, error_cov_j_sqrt, normalized=True)
+        self.kin_likelihood = KinLikelihood(
+            self.z_lens,
+            self.z_source,
+            sigma_v_measurement,
+            j_mean_list,
+            error_cov_measurement,
+            error_cov_j_sqrt,
+            normalized=True,
+        )
         self.ddt_gauss_likelihood = DdtGaussianLikelihood(**kwargs_ddt_gauss)
 
-        self.ddt_gauss_kin_likelihood = DdtGaussKinLikelihood(self.z_lens, self.z_source, self.ddt_mean, self.ddt_sigma,
-                                                              sigma_v_measurement, j_mean_list, error_cov_measurement,
-                                                              error_cov_j_sqrt, sigma_sys_error_include=False)
+        self.ddt_gauss_kin_likelihood = DdtGaussKinLikelihood(
+            self.z_lens,
+            self.z_source,
+            self.ddt_mean,
+            self.ddt_sigma,
+            sigma_v_measurement,
+            j_mean_list,
+            error_cov_measurement,
+            error_cov_j_sqrt,
+            sigma_sys_error_include=False,
+        )
         self.sigma_v_measurement = sigma_v_measurement
         self.error_cov_measurement = error_cov_measurement
 
     def test_log_likelihood(self):
         ddt, dd = 9, 0.9
-        lnlog_tot = self.ddt_gauss_kin_likelihood.log_likelihood(ddt, dd, aniso_scaling=None, sigma_v_sys_error=None)
+        lnlog_tot = self.ddt_gauss_kin_likelihood.log_likelihood(
+            ddt, dd, aniso_scaling=None, sigma_v_sys_error=None
+        )
         lnlog_ddt = self.ddt_gauss_likelihood.log_likelihood(ddt, dd)
-        lnlog_kin = self.kin_likelihood.log_likelihood(ddt, dd, aniso_scaling=None, sigma_v_sys_error=None)
+        lnlog_kin = self.kin_likelihood.log_likelihood(
+            ddt, dd, aniso_scaling=None, sigma_v_sys_error=None
+        )
         npt.assert_almost_equal(lnlog_tot, lnlog_ddt + lnlog_kin, decimal=5)
 
     def test_ddt_measurement(self):
@@ -51,15 +77,22 @@ class TestDdtGaussKinLikelihood(object):
         assert ddt_sigma == self.ddt_sigma
 
     def test_sigma_v_measurement(self):
-
-        sigma_v_measurement_, error_cov_measurement_ = self.ddt_gauss_kin_likelihood.sigma_v_measurement()
+        (
+            sigma_v_measurement_,
+            error_cov_measurement_,
+        ) = self.ddt_gauss_kin_likelihood.sigma_v_measurement()
         assert sigma_v_measurement_[0] == self.sigma_v_measurement[0]
         assert error_cov_measurement_[0, 0] == self.error_cov_measurement[0, 0]
 
-        sigma_v_predict, error_cov_predict = self.ddt_gauss_kin_likelihood.sigma_v_prediction(self.ddt_mean, self.dd_mean, aniso_scaling=1)
+        (
+            sigma_v_predict,
+            error_cov_predict,
+        ) = self.ddt_gauss_kin_likelihood.sigma_v_prediction(
+            self.ddt_mean, self.dd_mean, aniso_scaling=1
+        )
         assert sigma_v_predict[0] == self.sigma_v_measurement[0]
         assert error_cov_predict[0, 0] == 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_ddt_gauss_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_ddt_gauss_likelihood.py
@@ -5,7 +5,6 @@ import pytest
 
 
 class TestDdtDdGaussianLikelihood(object):
-
     def setup(self):
         np.random.seed(seed=41)
         self.z_lens = 0.8
@@ -14,8 +13,12 @@ class TestDdtDdGaussianLikelihood(object):
         self.ddt_mean = 10
         self.ddt_sigma = 0.1
 
-        self.kwargs_lens = {'z_lens': self.z_lens, 'z_source': self.z_source,
-                            'ddt_mean': self.ddt_mean, 'ddt_sigma': self.ddt_sigma}
+        self.kwargs_lens = {
+            "z_lens": self.z_lens,
+            "z_source": self.z_source,
+            "ddt_mean": self.ddt_mean,
+            "ddt_sigma": self.ddt_sigma,
+        }
 
     def test_log_likelihood(self):
         likelihood = DdtGaussianLikelihood(**self.kwargs_lens)
@@ -32,5 +35,5 @@ class TestDdtDdGaussianLikelihood(object):
         assert ddt_sigma == self.ddt_sigma
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_ddt_hist_kin_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_ddt_hist_kin_likelihood.py
@@ -1,5 +1,7 @@
 from hierarc.Likelihood.LensLikelihood.ddt_hist_likelihood import DdtHistLikelihood
-from hierarc.Likelihood.LensLikelihood.ddt_hist_kin_likelihood import DdtHistKinLikelihood
+from hierarc.Likelihood.LensLikelihood.ddt_hist_kin_likelihood import (
+    DdtHistKinLikelihood,
+)
 from hierarc.Likelihood.LensLikelihood.kin_likelihood import KinLikelihood
 from lenstronomy.Util import constants as const
 import numpy as np
@@ -8,16 +10,22 @@ import pytest
 
 
 class TestDdtHistKinHist(object):
-
     def setup(self):
-        self._ddt, self._dd = 2000., 1000.
+        self._ddt, self._dd = 2000.0, 1000.0
 
         self._sigma = 0.1
-        ddt_samples = np.random.normal(loc=self._ddt, scale=self._ddt * self._sigma, size=1000000)
+        ddt_samples = np.random.normal(
+            loc=self._ddt, scale=self._ddt * self._sigma, size=1000000
+        )
         ddt_weights = None  # np.random.uniform(low=0, high=1, size=100000)
 
-        self._ddthist = DdtHistLikelihood(z_lens=None, z_source=None, ddt_samples=ddt_samples,
-                                          ddt_weights=ddt_weights, nbins_hist=400)
+        self._ddthist = DdtHistLikelihood(
+            z_lens=None,
+            z_source=None,
+            ddt_samples=ddt_samples,
+            ddt_weights=ddt_weights,
+            nbins_hist=400,
+        )
 
         self._num_ifu = 10
         z_lens = 0.5
@@ -27,37 +35,61 @@ class TestDdtHistKinHist(object):
         scaling_ifu = 1
         sigma_v_measurement = np.sqrt(ds_dds * scaling_ifu * j_model) * const.c / 1000
         sigma_v_sigma = sigma_v_measurement * self._sigma
-        error_cov_measurement = np.diag(sigma_v_sigma ** 2)
+        error_cov_measurement = np.diag(sigma_v_sigma**2)
         error_cov_j_sqrt = np.diag(np.zeros_like(sigma_v_measurement))
-        self._kin_likelihood = KinLikelihood(z_lens, z_source, sigma_v_measurement, j_model, error_cov_measurement,
-                                             error_cov_j_sqrt)
-        self._ddt_kin_likelihood = DdtHistKinLikelihood(z_lens, z_source, ddt_samples, sigma_v_measurement,
-                                                        j_model, error_cov_measurement, error_cov_j_sqrt, ddt_weights=ddt_weights,
-                                                        kde_kernel='gaussian', bandwidth=20, nbins_hist=400)
+        self._kin_likelihood = KinLikelihood(
+            z_lens,
+            z_source,
+            sigma_v_measurement,
+            j_model,
+            error_cov_measurement,
+            error_cov_j_sqrt,
+        )
+        self._ddt_kin_likelihood = DdtHistKinLikelihood(
+            z_lens,
+            z_source,
+            ddt_samples,
+            sigma_v_measurement,
+            j_model,
+            error_cov_measurement,
+            error_cov_j_sqrt,
+            ddt_weights=ddt_weights,
+            kde_kernel="gaussian",
+            bandwidth=20,
+            nbins_hist=400,
+        )
         self.sigma_v_measurement = sigma_v_measurement
         self.error_cov_measurement = error_cov_measurement
 
     def test_log_likelihood(self):
-
         logl_max = self._ddt_kin_likelihood.log_likelihood(ddt=self._ddt, dd=self._dd)
-        logl = self._ddt_kin_likelihood.log_likelihood(self._ddt, self._dd / (1 + self._sigma) ** 2, aniso_scaling=None)
+        logl = self._ddt_kin_likelihood.log_likelihood(
+            self._ddt, self._dd / (1 + self._sigma) ** 2, aniso_scaling=None
+        )
         npt.assert_almost_equal(logl - logl_max, -self._num_ifu / 2, decimal=5)
 
     def test_ddt_measurement(self):
-
         ddt_mean, ddt_sigma = self._ddthist.ddt_measurement()
         npt.assert_almost_equal(ddt_mean / self._ddt, 1, decimal=3)
         npt.assert_almost_equal(ddt_sigma / (self._sigma * self._ddt), 1, decimal=3)
 
     def test_sigma_v_measurement(self):
-        sigma_v_measurement_, error_cov_measurement_ = self._ddt_kin_likelihood.sigma_v_measurement()
+        (
+            sigma_v_measurement_,
+            error_cov_measurement_,
+        ) = self._ddt_kin_likelihood.sigma_v_measurement()
         assert sigma_v_measurement_[0] == self.sigma_v_measurement[0]
         assert error_cov_measurement_[0, 0] == self.error_cov_measurement[0, 0]
 
-        sigma_v_predict, error_cov_predict = self._ddt_kin_likelihood.sigma_v_prediction(self._ddt, self._dd, aniso_scaling=1)
+        (
+            sigma_v_predict,
+            error_cov_predict,
+        ) = self._ddt_kin_likelihood.sigma_v_prediction(
+            self._ddt, self._dd, aniso_scaling=1
+        )
         assert sigma_v_predict[0] == self.sigma_v_measurement[0]
         assert error_cov_predict[0, 0] == 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_ddt_hist_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_ddt_hist_likelihood.py
@@ -1,23 +1,29 @@
-from hierarc.Likelihood.LensLikelihood.ddt_hist_likelihood import DdtHistLikelihood, DdtHistKDELikelihood
+from hierarc.Likelihood.LensLikelihood.ddt_hist_likelihood import (
+    DdtHistLikelihood,
+    DdtHistKDELikelihood,
+)
 import numpy as np
 import numpy.testing as npt
 import unittest
 
+
 def log_likelihood(hist_obj, mean, sig_factor):
     logl_max = hist_obj.log_likelihood(ddt=mean, dd=None)
     npt.assert_almost_equal(logl_max, 0, decimal=1)
-    logl_sigma = hist_obj.log_likelihood(ddt=mean*(1+sig_factor), dd=None)
-    npt.assert_almost_equal(logl_sigma-logl_max, -1/2., decimal=1)
-    logl_sigma = hist_obj.log_likelihood(ddt=mean*(1+2*sig_factor), dd=None)
-    npt.assert_almost_equal(logl_sigma-logl_max, -2**2/2., decimal=0)
-    logl_sigma = hist_obj.log_likelihood(ddt=mean*(1+1000*sig_factor), dd=None)
-    npt.assert_array_less(logl_sigma, -1e6) # some very small number
+    logl_sigma = hist_obj.log_likelihood(ddt=mean * (1 + sig_factor), dd=None)
+    npt.assert_almost_equal(logl_sigma - logl_max, -1 / 2.0, decimal=1)
+    logl_sigma = hist_obj.log_likelihood(ddt=mean * (1 + 2 * sig_factor), dd=None)
+    npt.assert_almost_equal(logl_sigma - logl_max, -(2**2) / 2.0, decimal=0)
+    logl_sigma = hist_obj.log_likelihood(ddt=mean * (1 + 1000 * sig_factor), dd=None)
+    npt.assert_array_less(logl_sigma, -1e6)  # some very small number
     assert np.exp(logl_sigma) == 0
+
 
 def ddt_measurement(hist_obj, mean, sig_factor):
     ddt_mean, ddt_sigma = hist_obj.ddt_measurement()
-    npt.assert_almost_equal(ddt_mean/mean, 1, decimal=3)
-    npt.assert_almost_equal(ddt_sigma/(sig_factor*mean), 1, decimal=3)
+    npt.assert_almost_equal(ddt_mean / mean, 1, decimal=3)
+    npt.assert_almost_equal(ddt_sigma / (sig_factor * mean), 1, decimal=3)
+
 
 class TestDdtHist(unittest.TestCase):
     @classmethod
@@ -25,33 +31,45 @@ class TestDdtHist(unittest.TestCase):
         np.random.seed(123)
         cls._ddt = 2000
         cls._sigma = 0.1
-        ddt_samples = np.random.normal(loc=cls._ddt, 
-                                       scale=cls._sigma*cls._ddt, 
-                                       size=1000000)
+        ddt_samples = np.random.normal(
+            loc=cls._ddt, scale=cls._sigma * cls._ddt, size=1000000
+        )
         weights = None  # np.random.uniform(low=0, high=1, size=100000)
         cls.test_log_likelihood = staticmethod(log_likelihood)
         cls.test_ddt_measurement = staticmethod(ddt_measurement)
-        cls._ddthist = DdtHistLikelihood(z_lens=None, z_source=None, 
-                                          ddt_samples=ddt_samples,
-                                          ddt_weights=weights, 
-                                          nbins_hist=400,
-                                          normalized=False)
-        cls._ddthist_scott = DdtHistLikelihood(z_lens=None, z_source=None, 
-                                               ddt_samples=ddt_samples,
-                                               ddt_weights=weights, 
-                                               binning_method='scott',
-                                               normalized=False)
-        cls._ddthist_silverman = DdtHistLikelihood(z_lens=None, z_source=None, 
-                                               ddt_samples=ddt_samples,
-                                               ddt_weights=weights, 
-                                               binning_method='silverman',
-                                               normalized=False)
-        cls._ddthist_bw = DdtHistLikelihood(z_lens=None, z_source=None, 
-                                            ddt_samples=ddt_samples,
-                                            ddt_weights=weights, 
-                                            # Very small bandwidth
-                                            binning_method=cls._ddt*cls._sigma*0.001,
-                                            normalized=False)
+        cls._ddthist = DdtHistLikelihood(
+            z_lens=None,
+            z_source=None,
+            ddt_samples=ddt_samples,
+            ddt_weights=weights,
+            nbins_hist=400,
+            normalized=False,
+        )
+        cls._ddthist_scott = DdtHistLikelihood(
+            z_lens=None,
+            z_source=None,
+            ddt_samples=ddt_samples,
+            ddt_weights=weights,
+            binning_method="scott",
+            normalized=False,
+        )
+        cls._ddthist_silverman = DdtHistLikelihood(
+            z_lens=None,
+            z_source=None,
+            ddt_samples=ddt_samples,
+            ddt_weights=weights,
+            binning_method="silverman",
+            normalized=False,
+        )
+        cls._ddthist_bw = DdtHistLikelihood(
+            z_lens=None,
+            z_source=None,
+            ddt_samples=ddt_samples,
+            ddt_weights=weights,
+            # Very small bandwidth
+            binning_method=cls._ddt * cls._sigma * 0.001,
+            normalized=False,
+        )
 
     def test_log_likelihood_nbins(self):
         self.test_log_likelihood(self._ddthist, self._ddt, self._sigma)
@@ -77,6 +95,7 @@ class TestDdtHist(unittest.TestCase):
     def test_ddt_measurement_bw(self):
         self.test_ddt_measurement(self._ddthist_bw, self._ddt, self._sigma)
 
+
 class TestDdtHistKDELikelihood(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -85,37 +104,55 @@ class TestDdtHistKDELikelihood(unittest.TestCase):
         ddt_samples = np.random.normal(loc=cls._ddt, scale=cls._sigma, size=1000000)
         weights = None  # np.random.uniform(low=0, high=1, size=100000)
         bandwidth = 0.1
-        cls._ddthist_normed = DdtHistKDELikelihood(z_lens=None, z_source=None, ddt_samples=ddt_samples,
-                                             kde_kernel='gaussian', ddt_weights=weights, bandwidth=bandwidth,
-                                             nbins_hist=400, normalized=True)
-        cls._ddthist = DdtHistKDELikelihood(z_lens=None, z_source=None, ddt_samples=ddt_samples,
-                                             kde_kernel='gaussian', ddt_weights=weights, bandwidth=bandwidth,
-                                             nbins_hist=400, normalized=False)
+        cls._ddthist_normed = DdtHistKDELikelihood(
+            z_lens=None,
+            z_source=None,
+            ddt_samples=ddt_samples,
+            kde_kernel="gaussian",
+            ddt_weights=weights,
+            bandwidth=bandwidth,
+            nbins_hist=400,
+            normalized=True,
+        )
+        cls._ddthist = DdtHistKDELikelihood(
+            z_lens=None,
+            z_source=None,
+            ddt_samples=ddt_samples,
+            kde_kernel="gaussian",
+            ddt_weights=weights,
+            bandwidth=bandwidth,
+            nbins_hist=400,
+            normalized=False,
+        )
 
     def test_log_likelihood(self):
-
         logl_max = self._ddthist_normed.log_likelihood(ddt=self._ddt, dd=None)
-        logl_sigma = self._ddthist_normed.log_likelihood(ddt=self._ddt + self._sigma, dd=None)
-        npt.assert_almost_equal(logl_sigma - logl_max, -1 / 2., decimal=1)
+        logl_sigma = self._ddthist_normed.log_likelihood(
+            ddt=self._ddt + self._sigma, dd=None
+        )
+        npt.assert_almost_equal(logl_sigma - logl_max, -1 / 2.0, decimal=1)
 
-        logl_sigma = self._ddthist_normed.log_likelihood(ddt=self._ddt + 2 * self._sigma, dd=None)
-        npt.assert_almost_equal(logl_sigma - logl_max, -2 ** 2 / 2., decimal=0)
+        logl_sigma = self._ddthist_normed.log_likelihood(
+            ddt=self._ddt + 2 * self._sigma, dd=None
+        )
+        npt.assert_almost_equal(logl_sigma - logl_max, -(2**2) / 2.0, decimal=0)
 
         logl_max = self._ddthist.log_likelihood(ddt=self._ddt, dd=None)
         print(logl_max, np.log(1 / self._sigma / np.sqrt(2 * np.pi)))
         npt.assert_almost_equal(logl_max, 0, decimal=2)
         logl_sigma = self._ddthist.log_likelihood(ddt=self._ddt + self._sigma, dd=None)
-        npt.assert_almost_equal(logl_sigma - logl_max, -1 / 2., decimal=1)
+        npt.assert_almost_equal(logl_sigma - logl_max, -1 / 2.0, decimal=1)
 
-        logl_sigma = self._ddthist.log_likelihood(ddt=self._ddt + 2 * self._sigma, dd=None)
-        npt.assert_almost_equal(logl_sigma - logl_max, -2 ** 2 / 2., decimal=0)
+        logl_sigma = self._ddthist.log_likelihood(
+            ddt=self._ddt + 2 * self._sigma, dd=None
+        )
+        npt.assert_almost_equal(logl_sigma - logl_max, -(2**2) / 2.0, decimal=0)
 
     def test_ddt_measurement(self):
-
         ddt_mean, ddt_sigma = self._ddthist.ddt_measurement()
         npt.assert_almost_equal(ddt_mean / self._ddt, 1, decimal=3)
         npt.assert_almost_equal(ddt_sigma / self._sigma, 1, decimal=3)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_ddt_log_norm_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_ddt_log_norm_likelihood.py
@@ -1,27 +1,35 @@
 import numpy as np
 import numpy.testing as npt
-from hierarc.Likelihood.LensLikelihood.ddt_lognorm_likelihood import DdtLogNormLikelihood
+from hierarc.Likelihood.LensLikelihood.ddt_lognorm_likelihood import (
+    DdtLogNormLikelihood,
+)
 from scipy.stats import lognorm
 import pytest
 
 
 class TestTDLikelihoodLogNorm(object):
-
     def setup(self):
         self.z_L = 0.8
         self.z_S = 3.0
         self.ddt_mu = 3.5
         self.ddt_sigma = 0.2
-        self.kwargs_post = {'z_lens': self.z_L, 'z_source': self.z_S, 'ddt_mu': self.ddt_mu, 'ddt_sigma': self.ddt_sigma}
+        self.kwargs_post = {
+            "z_lens": self.z_L,
+            "z_source": self.z_S,
+            "ddt_mu": self.ddt_mu,
+            "ddt_sigma": self.ddt_sigma,
+        }
         self.ddt_grid = np.arange(1, 10000, 50)
         self.scipy_lognorm = lognorm(scale=np.exp(self.ddt_mu), s=self.ddt_sigma)
         self.ll_object = DdtLogNormLikelihood(**self.kwargs_post)
 
     def test_log_likelihood(self):
         ll = self.ll_object.log_likelihood(self.ddt_grid)
-        scipy_ll = self.scipy_lognorm.logpdf(self.ddt_grid)  # with the constant term included
-        npt.assert_almost_equal(ll, scipy_ll + 0.5*np.log(2*np.pi), decimal=7)
+        scipy_ll = self.scipy_lognorm.logpdf(
+            self.ddt_grid
+        )  # with the constant term included
+        npt.assert_almost_equal(ll, scipy_ll + 0.5 * np.log(2 * np.pi), decimal=7)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_double_source_plane.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_double_source_plane.py
@@ -8,7 +8,7 @@ from hierarc.Likelihood.LensLikelihood.double_source_plane import (
 
 
 class TestDSPLikelihood(object):
-    """ """
+    """"""
 
     def setup(self):
         self.cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)

--- a/test/test_Likelihood/test_LensLikelihood/test_double_source_plane.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_double_source_plane.py
@@ -1,19 +1,23 @@
 from astropy.cosmology import FlatLambdaCDM
 import numpy as np
 import numpy.testing as npt
-from hierarc.Likelihood.LensLikelihood.double_source_plane import DSPLikelihood, beta_double_source_plane
+from hierarc.Likelihood.LensLikelihood.double_source_plane import (
+    DSPLikelihood,
+    beta_double_source_plane,
+)
 
 
 class TestDSPLikelihood(object):
-    """
+    """ """
 
-    """
     def setup(self):
         self.cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)
         self.zl = 0.5
         self.zs1 = 1
         self.zs2 = 2
-        self.beta = beta_double_source_plane(z_lens=self.zl, z_source_1=self.zs1, z_source_2=self.zs2, cosmo=self.cosmo)
+        self.beta = beta_double_source_plane(
+            z_lens=self.zl, z_source_1=self.zs1, z_source_2=self.zs2, cosmo=self.cosmo
+        )
         self.sigma_beta = 0.1
 
     def test_log_likelihood(self):
@@ -23,24 +27,49 @@ class TestDSPLikelihood(object):
         """
         # make cosmo instance
         # compute beta
-        dspl_likelihood = DSPLikelihood(z_lens=self.zl, z_source_1=self.zs1, z_source_2=self.zs2,
-                                        beta_dspl=self.beta, sigma_beta_dspl=self.sigma_beta, normalized=False)
+        dspl_likelihood = DSPLikelihood(
+            z_lens=self.zl,
+            z_source_1=self.zs1,
+            z_source_2=self.zs2,
+            beta_dspl=self.beta,
+            sigma_beta_dspl=self.sigma_beta,
+            normalized=False,
+        )
         log_l = dspl_likelihood.lens_log_likelihood(cosmo=self.cosmo)
         npt.assert_almost_equal(log_l, 0, decimal=5)
 
-        dspl_likelihood = DSPLikelihood(z_lens=self.zl, z_source_1=self.zs1, z_source_2=self.zs2,
-                                        beta_dspl=self.beta - self.sigma_beta, sigma_beta_dspl=self.sigma_beta,
-                                        normalized=False)
+        dspl_likelihood = DSPLikelihood(
+            z_lens=self.zl,
+            z_source_1=self.zs1,
+            z_source_2=self.zs2,
+            beta_dspl=self.beta - self.sigma_beta,
+            sigma_beta_dspl=self.sigma_beta,
+            normalized=False,
+        )
         log_l = dspl_likelihood.lens_log_likelihood(cosmo=self.cosmo)
         npt.assert_almost_equal(log_l, -0.5, decimal=5)
 
-        dspl_likelihood = DSPLikelihood(z_lens=self.zl, z_source_1=self.zs1, z_source_2=self.zs2,
-                                        beta_dspl=self.beta, sigma_beta_dspl=self.sigma_beta, normalized=True)
+        dspl_likelihood = DSPLikelihood(
+            z_lens=self.zl,
+            z_source_1=self.zs1,
+            z_source_2=self.zs2,
+            beta_dspl=self.beta,
+            sigma_beta_dspl=self.sigma_beta,
+            normalized=True,
+        )
         log_l = dspl_likelihood.lens_log_likelihood(cosmo=self.cosmo)
-        npt.assert_almost_equal(log_l, np.log(1/np.sqrt(2*np.pi) / self.sigma_beta), decimal=5)
+        npt.assert_almost_equal(
+            log_l, np.log(1 / np.sqrt(2 * np.pi) / self.sigma_beta), decimal=5
+        )
 
     def test_num_data(self):
-        dspl_likelihood = DSPLikelihood(z_lens=self.zl, z_source_1=self.zs1, z_source_2=self.zs2,
-                                        beta_dspl=self.beta, sigma_beta_dspl=self.sigma_beta, normalized=False)
+        dspl_likelihood = DSPLikelihood(
+            z_lens=self.zl,
+            z_source_1=self.zs1,
+            z_source_2=self.zs2,
+            beta_dspl=self.beta,
+            sigma_beta_dspl=self.sigma_beta,
+            normalized=False,
+        )
         num_data = dspl_likelihood.num_data()
         assert num_data == 1

--- a/test/test_Likelihood/test_LensLikelihood/test_ds_dds_gauss_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_ds_dds_gauss_likelihood.py
@@ -1,26 +1,31 @@
-from hierarc.Likelihood.LensLikelihood.ds_dds_gauss_likelihood import DsDdsGaussianLikelihood
+from hierarc.Likelihood.LensLikelihood.ds_dds_gauss_likelihood import (
+    DsDdsGaussianLikelihood,
+)
 import numpy as np
 import numpy.testing as npt
 import pytest
 
 
 class TestDdtDdGaussianLikelihood(object):
-
     def setup(self):
         np.random.seed(seed=41)
         self.z_lens = 0.8
         self.z_source = 3.0
 
-        self.ds_dds_mean = 2.
+        self.ds_dds_mean = 2.0
         self.ds_dds_sigma = 0.2
 
-        self.kwargs_lens = {'z_lens': self.z_lens, 'z_source': self.z_source,
-                            'ds_dds_mean': self.ds_dds_mean, 'ds_dds_sigma': self.ds_dds_sigma}
+        self.kwargs_lens = {
+            "z_lens": self.z_lens,
+            "z_source": self.z_source,
+            "ds_dds_mean": self.ds_dds_mean,
+            "ds_dds_sigma": self.ds_dds_sigma,
+        }
 
     def test_log_likelihood(self):
         likelihood = DsDdsGaussianLikelihood(**self.kwargs_lens)
 
-        dd = 1.
+        dd = 1.0
         ddt = self.ds_dds_mean * dd * (1 + self.z_lens)
         ddt_1_sigma = (self.ds_dds_mean + self.ds_dds_sigma) * dd * (1 + self.z_lens)
 
@@ -29,10 +34,10 @@ class TestDdtDdGaussianLikelihood(object):
         lnlog = likelihood.log_likelihood(ddt=ddt_1_sigma, dd=dd)
         npt.assert_almost_equal(lnlog, -0.5, decimal=5)
 
-        aniso_scaling = [1./(1 + self.ds_dds_sigma/self.ds_dds_mean)]
+        aniso_scaling = [1.0 / (1 + self.ds_dds_sigma / self.ds_dds_mean)]
         lnlog = likelihood.log_likelihood(ddt=ddt, dd=dd, aniso_scaling=aniso_scaling)
         npt.assert_almost_equal(lnlog, -0.5, decimal=5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_kin_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_kin_likelihood.py
@@ -7,7 +7,6 @@ from lenstronomy.Util import constants as const
 
 
 class TestKinLikelihood(object):
-
     def setup(self):
         np.random.seed(seed=41)
 
@@ -15,28 +14,44 @@ class TestKinLikelihood(object):
         num_ifu = 10
         z_lens = 0.5
         z_source = 2
-        ddt, dd = 5000., 2000.
+        ddt, dd = 5000.0, 2000.0
         ds_dds = ddt / dd / (1 + z_lens)
         j_mean_list = np.ones(num_ifu)
         scaling_ifu = 1
-        sigma_v_measurement = np.sqrt(ds_dds * scaling_ifu * j_mean_list) * const.c / 1000
-        sigma_v_sigma = sigma_v_measurement/10.
-        error_cov_measurement = np.diag(sigma_v_sigma ** 2)
+        sigma_v_measurement = (
+            np.sqrt(ds_dds * scaling_ifu * j_mean_list) * const.c / 1000
+        )
+        sigma_v_sigma = sigma_v_measurement / 10.0
+        error_cov_measurement = np.diag(sigma_v_sigma**2)
         error_cov_j_sqrt = np.diag(np.zeros_like(sigma_v_measurement))
-        kin_likelihood = KinLikelihood(z_lens, z_source, sigma_v_measurement, j_mean_list, error_cov_measurement,
-                                       error_cov_j_sqrt, normalized=False)
+        kin_likelihood = KinLikelihood(
+            z_lens,
+            z_source,
+            sigma_v_measurement,
+            j_mean_list,
+            error_cov_measurement,
+            error_cov_j_sqrt,
+            normalized=False,
+        )
         logl = kin_likelihood.log_likelihood(ddt, dd, aniso_scaling=None)
         npt.assert_almost_equal(logl, 0, decimal=5)
-        logl = kin_likelihood.log_likelihood(ddt*(0.9**2), dd, aniso_scaling=None)
-        npt.assert_almost_equal(logl, -num_ifu/2, decimal=5)
-        logl = kin_likelihood.log_likelihood(ddt * (1 - np.sqrt(0.1**2 + 0.1**2))**2, dd, aniso_scaling=None)
+        logl = kin_likelihood.log_likelihood(ddt * (0.9**2), dd, aniso_scaling=None)
+        npt.assert_almost_equal(logl, -num_ifu / 2, decimal=5)
+        logl = kin_likelihood.log_likelihood(
+            ddt * (1 - np.sqrt(0.1**2 + 0.1**2)) ** 2, dd, aniso_scaling=None
+        )
         npt.assert_almost_equal(logl, -num_ifu, decimal=5)
 
-        sigma_v_measurement_, error_cov_measurement_ = kin_likelihood.sigma_v_measurement()
+        (
+            sigma_v_measurement_,
+            error_cov_measurement_,
+        ) = kin_likelihood.sigma_v_measurement()
         assert sigma_v_measurement_[0] == sigma_v_measurement[0]
         assert error_cov_measurement_[0, 0] == error_cov_measurement[0, 0]
 
-        sigma_v_predict, error_cov_predict = kin_likelihood.sigma_v_prediction(ddt, dd, aniso_scaling=1)
+        sigma_v_predict, error_cov_predict = kin_likelihood.sigma_v_prediction(
+            ddt, dd, aniso_scaling=1
+        )
         assert sigma_v_predict[0] == sigma_v_measurement[0]
         assert error_cov_predict[0, 0] == 0
 
@@ -44,50 +59,81 @@ class TestKinLikelihood(object):
         num_ifu = 10
         z_lens = 0.5
         z_source = 2
-        ddt, dd = 5000., 2000.
+        ddt, dd = 5000.0, 2000.0
         ds_dds = ddt / dd / (1 + z_lens)
         j_mean_list = np.ones(num_ifu)
         scaling_ifu = 1
-        sigma_v_measurement = np.sqrt(ds_dds * scaling_ifu * j_mean_list) * const.c / 1000
-        sigma_v_sigma = sigma_v_measurement / 1000.
-        error_cov_measurement = np.diag(sigma_v_sigma ** 2)
+        sigma_v_measurement = (
+            np.sqrt(ds_dds * scaling_ifu * j_mean_list) * const.c / 1000
+        )
+        sigma_v_sigma = sigma_v_measurement / 1000.0
+        error_cov_measurement = np.diag(sigma_v_sigma**2)
         error_cov_j_sqrt = np.diag(np.zeros_like(sigma_v_measurement))
-        ifu_likelihood = KinLikelihood(z_lens, z_source, sigma_v_measurement, j_mean_list, error_cov_measurement,
-                                       error_cov_j_sqrt, normalized=False, sigma_sys_error_include=True)
-        logl = ifu_likelihood.log_likelihood(ddt * (1 - np.sqrt(0.1**2)) ** 2, dd, aniso_scaling=1, sigma_v_sys_error=0.1)
-        npt.assert_almost_equal(logl, -1/2., decimal=5)
+        ifu_likelihood = KinLikelihood(
+            z_lens,
+            z_source,
+            sigma_v_measurement,
+            j_mean_list,
+            error_cov_measurement,
+            error_cov_j_sqrt,
+            normalized=False,
+            sigma_sys_error_include=True,
+        )
+        logl = ifu_likelihood.log_likelihood(
+            ddt * (1 - np.sqrt(0.1**2)) ** 2,
+            dd,
+            aniso_scaling=1,
+            sigma_v_sys_error=0.1,
+        )
+        npt.assert_almost_equal(logl, -1 / 2.0, decimal=5)
 
     def test_log_likelihood_marg(self):
         num_ifu = 1
         z_lens = 0.5
         z_source = 2
-        ddt, dd = 5000., 2000.
+        ddt, dd = 5000.0, 2000.0
         ds_dds = ddt / dd / (1 + z_lens)
         j_mean_list = np.ones(num_ifu) / 10**6
         scaling_ifu = 1
-        sigma_v_measurement = np.sqrt(ds_dds * scaling_ifu * j_mean_list) * const.c / 1000
-        sigma_v_sigma = sigma_v_measurement / 100.
-        error_cov_measurement = np.diag(sigma_v_sigma ** 2)
-        error_cov_j_sqrt = np.diag((np.sqrt(j_mean_list) / 100)**2)
-        print(error_cov_j_sqrt, 'cov_j_sqrt')
-        ifu_likelihood = KinLikelihood(z_lens, z_source, sigma_v_measurement, j_mean_list, error_cov_measurement,
-                                       error_cov_j_sqrt, normalized=True, sigma_sys_error_include=True)
+        sigma_v_measurement = (
+            np.sqrt(ds_dds * scaling_ifu * j_mean_list) * const.c / 1000
+        )
+        sigma_v_sigma = sigma_v_measurement / 100.0
+        error_cov_measurement = np.diag(sigma_v_sigma**2)
+        error_cov_j_sqrt = np.diag((np.sqrt(j_mean_list) / 100) ** 2)
+        print(error_cov_j_sqrt, "cov_j_sqrt")
+        ifu_likelihood = KinLikelihood(
+            z_lens,
+            z_source,
+            sigma_v_measurement,
+            j_mean_list,
+            error_cov_measurement,
+            error_cov_j_sqrt,
+            normalized=True,
+            sigma_sys_error_include=True,
+        )
         logl = ifu_likelihood.log_likelihood(ddt, dd, aniso_scaling=1)
         aniso_scaling = 0.8
-        logl_ani = ifu_likelihood.log_likelihood(ddt, dd*aniso_scaling, aniso_scaling=aniso_scaling)
+        logl_ani = ifu_likelihood.log_likelihood(
+            ddt, dd * aniso_scaling, aniso_scaling=aniso_scaling
+        )
         npt.assert_almost_equal(logl_ani - logl, 0, decimal=1)
 
         # here we test that a Monte Carlo marginalization of a systematic uncertainty leads to the same result as the
         # analytical Gaussian calculation in the covariance matrix normalization
         sigma_v_sys_error = 0.1
-        logl = ifu_likelihood.log_likelihood(ddt, dd, aniso_scaling=1, sigma_v_sys_error=sigma_v_sys_error)
+        logl = ifu_likelihood.log_likelihood(
+            ddt, dd, aniso_scaling=1, sigma_v_sys_error=sigma_v_sys_error
+        )
         l_sum = 0
         num_sample = 10000
         for i in range(num_sample):
             sigma_v_pert = np.random.normal(loc=0, scale=sigma_v_sys_error)
-            logl_i = ifu_likelihood.log_likelihood(ddt, dd, aniso_scaling=1, sigma_v_sys_offset=sigma_v_pert)
+            logl_i = ifu_likelihood.log_likelihood(
+                ddt, dd, aniso_scaling=1, sigma_v_sys_offset=sigma_v_pert
+            )
             l_sum += np.exp(logl_i)
-        logl_average = np.log(l_sum/num_sample)
+        logl_average = np.log(l_sum / num_sample)
         npt.assert_almost_equal(logl, logl_average, decimal=1)
 
     def test_log_likelihood_invert_error(self):
@@ -95,20 +141,25 @@ class TestKinLikelihood(object):
         test that in the case of a none-invertable covariance matrix -np.inf is returned by the likelihood statement
 
         """
-        ifu_likelihood = KinLikelihood(z_lens=0.5, z_source=2., sigma_v_measurement=[100],
-                                       j_model=[1], error_cov_measurement=[0], error_cov_j_sqrt=[0], normalized=True,
-                                       sigma_sys_error_include=True)
+        ifu_likelihood = KinLikelihood(
+            z_lens=0.5,
+            z_source=2.0,
+            sigma_v_measurement=[100],
+            j_model=[1],
+            error_cov_measurement=[0],
+            error_cov_j_sqrt=[0],
+            normalized=True,
+            sigma_sys_error_include=True,
+        )
         logl = ifu_likelihood.log_likelihood(ddt=1, dd=1, aniso_scaling=1)
         assert logl == -np.inf
 
 
 class TestRaise(unittest.TestCase):
-
     def test_raise(self):
-
         with self.assertRaises(ValueError):
             raise ValueError()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_kin_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_kin_likelihood.py
@@ -137,10 +137,8 @@ class TestKinLikelihood(object):
         npt.assert_almost_equal(logl, logl_average, decimal=1)
 
     def test_log_likelihood_invert_error(self):
-        """
-        test that in the case of a none-invertable covariance matrix -np.inf is returned by the likelihood statement
-
-        """
+        """Test that in the case of a none-invertable covariance matrix -np.inf is
+        returned by the likelihood statement."""
         ifu_likelihood = KinLikelihood(
             z_lens=0.5,
             z_source=2.0,

--- a/test/test_Likelihood/test_LensLikelihood/test_mag_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_mag_likelihood.py
@@ -6,7 +6,6 @@ from lenstronomy.Util.data_util import magnitude2cps
 
 
 class TestMagnificationLikelihood(object):
-
     def setup(self):
         pass
 
@@ -15,24 +14,28 @@ class TestMagnificationLikelihood(object):
         magnitude_intrinsic = 19
         magnitude_zero_point = 20
 
-        amp_int = magnitude2cps(magnitude=magnitude_intrinsic, magnitude_zero_point=magnitude_zero_point)
+        amp_int = magnitude2cps(
+            magnitude=magnitude_intrinsic, magnitude_zero_point=magnitude_zero_point
+        )
         magnification_model = np.ones(num)
         magnification_model_cov = np.diag((magnification_model / 10) ** 2)
 
         magnitude_measured = magnification_model * amp_int
-        magnitude_measured_cov = np.diag((magnitude_measured/10)**2)
+        magnitude_measured_cov = np.diag((magnitude_measured / 10) ** 2)
 
         # un-normalized likelihood
-        likelihood = MagnificationLikelihood(amp_measured=magnitude_measured,
-                                             cov_amp_measured=magnitude_measured_cov,
-                                             magnification_model=magnification_model,
-                                             cov_magnification_model=magnification_model_cov,
-                                             magnitude_zero_point=magnitude_zero_point)
+        likelihood = MagnificationLikelihood(
+            amp_measured=magnitude_measured,
+            cov_amp_measured=magnitude_measured_cov,
+            magnification_model=magnification_model,
+            cov_magnification_model=magnification_model_cov,
+            magnitude_zero_point=magnitude_zero_point,
+        )
 
         logl = likelihood.log_likelihood(mu_intrinsic=magnitude_intrinsic)
         _, cov_tot = likelihood._scale_model(mu_intrinsic=magnitude_intrinsic)
         sign_det, lndet = np.linalg.slogdet(cov_tot)
-        logl_test = -1 / 2. * (likelihood.num_data * np.log(2 * np.pi) + lndet)
+        logl_test = -1 / 2.0 * (likelihood.num_data * np.log(2 * np.pi) + lndet)
         npt.assert_almost_equal(logl, logl_test, decimal=6)
 
         num = 4
@@ -42,13 +45,15 @@ class TestMagnificationLikelihood(object):
         magnitude_measured = magnification_model * amp_int
         magnitude_measured_cov = np.zeros((num, num))
 
-        likelihood = MagnificationLikelihood(amp_measured=magnitude_measured,
-                                             cov_amp_measured=magnitude_measured_cov,
-                                             magnification_model=magnification_model,
-                                             cov_magnification_model=magnification_model_cov)
+        likelihood = MagnificationLikelihood(
+            amp_measured=magnitude_measured,
+            cov_amp_measured=magnitude_measured_cov,
+            magnification_model=magnification_model,
+            cov_magnification_model=magnification_model_cov,
+        )
         logl = likelihood.log_likelihood(mu_intrinsic=1)
         assert logl == -np.inf
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_td_mag_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_td_mag_likelihood.py
@@ -7,7 +7,6 @@ from lenstronomy.Util.data_util import magnitude2cps
 
 
 class TestMagnificationLikelihood(object):
-
     def setup(self):
         pass
 
@@ -18,25 +17,37 @@ class TestMagnificationLikelihood(object):
         magnitude_intrinsic = 19
         magnitude_zero_point = 20
 
-        amp_int = magnitude2cps(magnitude=magnitude_intrinsic, magnitude_zero_point=magnitude_zero_point)
+        amp_int = magnitude2cps(
+            magnitude=magnitude_intrinsic, magnitude_zero_point=magnitude_zero_point
+        )
 
         amp_measured = magnification_model * amp_int
-        cov_amp_measured = np.diag((amp_measured/10)**2)
+        cov_amp_measured = np.diag((amp_measured / 10) ** 2)
         time_delay_measured = np.ones(num - 1) * 10
-        cov_td_measured = np.ones((num-1, num-1))
-        fermat_unit_conversion = const.Mpc / const.c / const.day_s * const.arcsec ** 2
+        cov_td_measured = np.ones((num - 1, num - 1))
+        fermat_unit_conversion = const.Mpc / const.c / const.day_s * const.arcsec**2
         fermat_diff = time_delay_measured / fermat_unit_conversion / ddt
         model_vector = np.append(fermat_diff, magnification_model)
-        cov_model = np.diag((model_vector/10)**2)
+        cov_model = np.diag((model_vector / 10) ** 2)
 
         # un-normalized likelihood
-        likelihood = TDMagLikelihood(time_delay_measured, cov_td_measured, amp_measured, cov_amp_measured,
-                 fermat_diff, magnification_model, cov_model, magnitude_zero_point=magnitude_zero_point)
+        likelihood = TDMagLikelihood(
+            time_delay_measured,
+            cov_td_measured,
+            amp_measured,
+            cov_amp_measured,
+            fermat_diff,
+            magnification_model,
+            cov_model,
+            magnitude_zero_point=magnitude_zero_point,
+        )
 
         logl = likelihood.log_likelihood(ddt=ddt, mu_intrinsic=magnitude_intrinsic)
-        model_vector, cov_tot = likelihood._model_cov(ddt, mu_intrinsic=magnitude_intrinsic)
+        model_vector, cov_tot = likelihood._model_cov(
+            ddt, mu_intrinsic=magnitude_intrinsic
+        )
         sign_det, lndet = np.linalg.slogdet(cov_tot)
-        logl_norm = -1 / 2. * (likelihood.num_data * np.log(2 * np.pi) + lndet)
+        logl_norm = -1 / 2.0 * (likelihood.num_data * np.log(2 * np.pi) + lndet)
         npt.assert_almost_equal(logl, logl_norm, decimal=6)
 
         num = 4
@@ -47,11 +58,19 @@ class TestMagnificationLikelihood(object):
         amp_measured = magnification_model * amp_int
         cov_model = np.zeros((num + num - 1, num + num - 1))
 
-        likelihood = TDMagLikelihood(time_delay_measured, cov_td_measured, amp_measured, cov_amp_measured,
-                 fermat_diff, magnification_model, cov_model, magnitude_zero_point=magnitude_zero_point)
+        likelihood = TDMagLikelihood(
+            time_delay_measured,
+            cov_td_measured,
+            amp_measured,
+            cov_amp_measured,
+            fermat_diff,
+            magnification_model,
+            cov_model,
+            magnitude_zero_point=magnitude_zero_point,
+        )
         logl = likelihood.log_likelihood(ddt=ddt, mu_intrinsic=1)
         assert logl == -np.inf
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_LensLikelihood/test_td_mag_magnitude_likelihood.py
+++ b/test/test_Likelihood/test_LensLikelihood/test_td_mag_magnitude_likelihood.py
@@ -3,12 +3,13 @@ import numpy as np
 import numpy.testing as npt
 from lenstronomy.Util import constants as const
 from hierarc.Likelihood.LensLikelihood.td_mag_likelihood import TDMagLikelihood
-from hierarc.Likelihood.LensLikelihood.td_mag_magnitude_likelihood import TDMagMagnitudeLikelihood
+from hierarc.Likelihood.LensLikelihood.td_mag_magnitude_likelihood import (
+    TDMagMagnitudeLikelihood,
+)
 from lenstronomy.Util.data_util import magnitude2cps
 
 
 class TestMagnificationLikelihood(object):
-
     def setup(self):
         pass
 
@@ -19,40 +20,64 @@ class TestMagnificationLikelihood(object):
         magnitude_intrinsic = 19
 
         magnitude_zero_point = 20
-        amp_int = magnitude2cps(magnitude=magnitude_intrinsic, magnitude_zero_point=magnitude_zero_point)
+        amp_int = magnitude2cps(
+            magnitude=magnitude_intrinsic, magnitude_zero_point=magnitude_zero_point
+        )
 
         amp_measured = magnification_model * amp_int
         rel_sigma = 0.1
-        cov_amp_measured = np.diag((amp_measured*rel_sigma)**2)
-        magnification_model_magnitude = - 2.5 * np.log10(magnification_model)
+        cov_amp_measured = np.diag((amp_measured * rel_sigma) ** 2)
+        magnification_model_magnitude = -2.5 * np.log10(magnification_model)
         magnitude_measured = magnitude_intrinsic - 2.5 * np.log10(magnification_model)
-        cov_magnitude_measured = np.diag(rel_sigma * 1.086 * np.ones(num))  #  translating relative scatter in linear flux units to astronomical magnitudes
+        cov_magnitude_measured = np.diag(
+            rel_sigma * 1.086 * np.ones(num)
+        )  #  translating relative scatter in linear flux units to astronomical magnitudes
 
         time_delay_measured = np.ones(num - 1) * 10
-        cov_td_measured = np.ones((num-1, num-1))
-        fermat_unit_conversion = const.Mpc / const.c / const.day_s * const.arcsec ** 2
+        cov_td_measured = np.ones((num - 1, num - 1))
+        fermat_unit_conversion = const.Mpc / const.c / const.day_s * const.arcsec**2
         fermat_diff = time_delay_measured / fermat_unit_conversion / ddt
         model_vector = np.append(fermat_diff, magnification_model)
-        cov_model = np.diag((model_vector/10)**2)
+        cov_model = np.diag((model_vector / 10) ** 2)
 
-        cov_model_magnitude = np.diag(np.append(fermat_diff * rel_sigma, rel_sigma * 1.086 * np.ones(num)))
+        cov_model_magnitude = np.diag(
+            np.append(fermat_diff * rel_sigma, rel_sigma * 1.086 * np.ones(num))
+        )
         # un-normalized likelihood, comparing linear flux likelihood and magnification likelihood
 
         # linear flux likelihood
-        likelihood = TDMagLikelihood(time_delay_measured, cov_td_measured, amp_measured, cov_amp_measured,
-                 fermat_diff, magnification_model, cov_model, magnitude_zero_point=magnitude_zero_point)
+        likelihood = TDMagLikelihood(
+            time_delay_measured,
+            cov_td_measured,
+            amp_measured,
+            cov_amp_measured,
+            fermat_diff,
+            magnification_model,
+            cov_model,
+            magnitude_zero_point=magnitude_zero_point,
+        )
 
         logl = likelihood.log_likelihood(ddt=ddt, mu_intrinsic=magnitude_intrinsic)
-        model_vector, cov_tot = likelihood._model_cov(ddt, mu_intrinsic=magnitude_intrinsic)
+        model_vector, cov_tot = likelihood._model_cov(
+            ddt, mu_intrinsic=magnitude_intrinsic
+        )
         sign_det, lndet = np.linalg.slogdet(cov_tot)
-        logl_norm = -1 / 2. * (likelihood.num_data * np.log(2 * np.pi) + lndet)
+        logl_norm = -1 / 2.0 * (likelihood.num_data * np.log(2 * np.pi) + lndet)
         npt.assert_almost_equal(logl, logl_norm, decimal=6)
 
         # astronomical magnitude likelihood
-        likelihood_magnitude = TDMagMagnitudeLikelihood(time_delay_measured, cov_td_measured, magnitude_measured,
-                                              cov_magnitude_measured, fermat_diff, magnification_model_magnitude,
-                                              cov_model_magnitude)
-        logl_magnitude = likelihood_magnitude.log_likelihood(ddt=ddt, mu_intrinsic=magnitude_intrinsic)
+        likelihood_magnitude = TDMagMagnitudeLikelihood(
+            time_delay_measured,
+            cov_td_measured,
+            magnitude_measured,
+            cov_magnitude_measured,
+            fermat_diff,
+            magnification_model_magnitude,
+            cov_model_magnitude,
+        )
+        logl_magnitude = likelihood_magnitude.log_likelihood(
+            ddt=ddt, mu_intrinsic=magnitude_intrinsic
+        )
         npt.assert_almost_equal(logl_magnitude - logl, 0, decimal=1)
 
         num = 4
@@ -62,12 +87,18 @@ class TestMagnificationLikelihood(object):
         magnitude_measured = magnitude_intrinsic - 2.5 * np.log10(magnification_model)
         cov_model = np.zeros((num + num - 1, num + num - 1))
 
-        likelihood = TDMagMagnitudeLikelihood(time_delay_measured, cov_td_measured, magnitude_measured,
-                                              cov_magnitude_measured, fermat_diff, magnification_model_magnitude,
-                                              cov_model)
+        likelihood = TDMagMagnitudeLikelihood(
+            time_delay_measured,
+            cov_td_measured,
+            magnitude_measured,
+            cov_magnitude_measured,
+            fermat_diff,
+            magnification_model_magnitude,
+            cov_model,
+        )
         logl = likelihood.log_likelihood(ddt=ddt, mu_intrinsic=1)
         assert logl == -np.inf
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_SneLikelihood/test_pantheon_plus_data.py
+++ b/test/test_Likelihood/test_SneLikelihood/test_pantheon_plus_data.py
@@ -5,7 +5,6 @@ from hierarc.Likelihood.SneLikelihood.sne_pantheon_plus import PantheonPlusData
 
 
 class TestPantheonPlusData(object):
-
     def setup(self):
         pass
 
@@ -15,7 +14,7 @@ class TestPantheonPlusData(object):
         cov_mag = data.cov_mag_b
         zhel = data.zHEL
         zcmb = data.zCMB
-        print(zcmb, 'zcmb')
+        print(zcmb, "zcmb")
         npt.assert_almost_equal(zcmb[0], 0.01016)
         assert len(mag_mean) == len(zhel)
         assert len(zhel) == len(zcmb)

--- a/test/test_Likelihood/test_SneLikelihood/test_sne_likelihood.py
+++ b/test/test_Likelihood/test_SneLikelihood/test_sne_likelihood.py
@@ -5,7 +5,6 @@ import numpy.testing as npt
 
 
 class TestSnePantheon(object):
-
     def setup(self):
         np.random.seed(42)
         # define redshifts
@@ -25,23 +24,35 @@ class TestSnePantheon(object):
 
         # compute luminosity distances
         angular_diameter_distances = cosmo_true.angular_diameter_distance(zcmb).value
-        lum_dists_true = (5 * np.log10((1 + zhel) * (1 + zcmb) * angular_diameter_distances))
+        lum_dists_true = 5 * np.log10(
+            (1 + zhel) * (1 + zcmb) * angular_diameter_distances
+        )
 
-        angular_diameter_distance_pivot = cosmo_true.angular_diameter_distance(z_pivot).value
-        lum_dist_pivot = (5 * np.log10((1 + z_pivot) * (1 + z_pivot) * angular_diameter_distance_pivot))
+        angular_diameter_distance_pivot = cosmo_true.angular_diameter_distance(
+            z_pivot
+        ).value
+        lum_dist_pivot = 5 * np.log10(
+            (1 + z_pivot) * (1 + z_pivot) * angular_diameter_distance_pivot
+        )
 
         # draw from scatter
 
         sigma_m_z = 0.1
-        cov_mag = np.ones((num, num)) * 0.05 ** 2 + np.diag(
-            np.ones(num) * 0.1 ** 2)  # full covariance matrix of systematics
-        cov_mag_measure = cov_mag + np.diag(np.ones(num) * sigma_m_z ** 2)
+        cov_mag = np.ones((num, num)) * 0.05**2 + np.diag(
+            np.ones(num) * 0.1**2
+        )  # full covariance matrix of systematics
+        cov_mag_measure = cov_mag + np.diag(np.ones(num) * sigma_m_z**2)
         mags = m_apparent + lum_dists_true - lum_dist_pivot
 
         mag_mean = np.random.multivariate_normal(mags, cov_mag_measure)
-        kwargs_sne_likelihood = {'mag_mean': mag_mean, 'cov_mag': cov_mag, 'zhel': zhel, 'zcmb': zcmb}
+        kwargs_sne_likelihood = {
+            "mag_mean": mag_mean,
+            "cov_mag": cov_mag,
+            "zhel": zhel,
+            "zcmb": zcmb,
+        }
 
-        self.likelihood = SneLikelihood(sample_name='CUSTOM', **kwargs_sne_likelihood)
+        self.likelihood = SneLikelihood(sample_name="CUSTOM", **kwargs_sne_likelihood)
         self.lum_dists_true = lum_dists_true
         self.m_apparent_true = m_apparent
         self.sigma_m_true = sigma_m_z
@@ -49,21 +60,34 @@ class TestSnePantheon(object):
         self.z_anchor = z_pivot
 
     def test_log_likelihood(self):
-        logL = self.likelihood.log_likelihood(self.cosmo_true, apparent_m_z=self.m_apparent_true,
-                                              sigma_m_z=self.sigma_m_true, z_anchor=self.z_anchor)
+        logL = self.likelihood.log_likelihood(
+            self.cosmo_true,
+            apparent_m_z=self.m_apparent_true,
+            sigma_m_z=self.sigma_m_true,
+            z_anchor=self.z_anchor,
+        )
 
-        logL_high = self.likelihood.log_likelihood(self.cosmo_true, apparent_m_z=self.m_apparent_true + 0.2,
-                                              sigma_m_z=self.sigma_m_true, z_anchor=self.z_anchor)
+        logL_high = self.likelihood.log_likelihood(
+            self.cosmo_true,
+            apparent_m_z=self.m_apparent_true + 0.2,
+            sigma_m_z=self.sigma_m_true,
+            z_anchor=self.z_anchor,
+        )
         assert logL > logL_high
 
-        logL_low = self.likelihood.log_likelihood(self.cosmo_true, apparent_m_z=self.m_apparent_true - 0.2,
-                                                   sigma_m_z=self.sigma_m_true, z_anchor=self.z_anchor)
+        logL_low = self.likelihood.log_likelihood(
+            self.cosmo_true,
+            apparent_m_z=self.m_apparent_true - 0.2,
+            sigma_m_z=self.sigma_m_true,
+            z_anchor=self.z_anchor,
+        )
         assert logL > logL_low
 
     def test_pantheon_plus(self):
-        likelihood = SneLikelihood(sample_name='PantheonPlus')
+        likelihood = SneLikelihood(sample_name="PantheonPlus")
         om_mean, om_sigma = 0.338, 0.018  # from Brout et al. 2022
         from astropy.cosmology import FlatLambdaCDM
+
         """
         om_list = np.linspace(start=0.2, stop=0.4, num=20)
         logL_list = []
@@ -86,5 +110,5 @@ class TestSnePantheon(object):
         npt.assert_almost_equal(logL_sigma_neg - logL_mean, -0.132, decimal=1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_SneLikelihood/test_sne_likelihood_custom.py
+++ b/test/test_Likelihood/test_SneLikelihood/test_sne_likelihood_custom.py
@@ -5,7 +5,6 @@ import pytest
 
 
 class TestCustomSneLikelihood(object):
-
     def setup(self):
         np.random.seed(42)
         # define redshifts
@@ -24,11 +23,15 @@ class TestCustomSneLikelihood(object):
 
         # compute luminosity distances
         angular_diameter_distances = cosmo_true.angular_diameter_distance(zcmb).value
-        lum_dists_true = (5 * np.log10((1 + zhel) * (1 + zcmb) * angular_diameter_distances))
+        lum_dists_true = 5 * np.log10(
+            (1 + zhel) * (1 + zcmb) * angular_diameter_distances
+        )
 
         # draw from scatter
         sigma_m_z = 0.1
-        cov_mag = np.ones((num, num)) * 0.05**2 + np.diag(np.ones(num) * 0.1**2)  # full covariance matrix of systematics
+        cov_mag = np.ones((num, num)) * 0.05**2 + np.diag(
+            np.ones(num) * 0.1**2
+        )  # full covariance matrix of systematics
         cov_mag_measure = cov_mag + np.diag(np.ones(num) * sigma_m_z**2)
         mags = m_apparent + lum_dists_true
 
@@ -40,38 +43,51 @@ class TestCustomSneLikelihood(object):
         self.sigma_m_true = sigma_m_z
 
     def test_log_likelihood_lum_dist(self):
-
         # check whether truth as input results in a chi2 around 1
-        logL = self.likelihood.log_likelihood_lum_dist(self.lum_dists_true, estimated_scriptm=self.m_apparent_true,
-                                                       sigma_m_z=self.sigma_m_true)
+        logL = self.likelihood.log_likelihood_lum_dist(
+            self.lum_dists_true,
+            estimated_scriptm=self.m_apparent_true,
+            sigma_m_z=self.sigma_m_true,
+        )
 
-
-
-        cov_mag, inv_cov = self.likelihood._inverse_covariance_matrix(sigma_m_z=self.sigma_m_true)
+        cov_mag, inv_cov = self.likelihood._inverse_covariance_matrix(
+            sigma_m_z=self.sigma_m_true
+        )
         sign_det, lndet = np.linalg.slogdet(cov_mag)
-        logL_unnorm = logL + 1 / 2. * (len(self.lum_dists_true) * np.log(2 * np.pi) + lndet)
-        npt.assert_almost_equal(-logL_unnorm * 2 / len(self.lum_dists_true), 1, decimal=0)
+        logL_unnorm = logL + 1 / 2.0 * (
+            len(self.lum_dists_true) * np.log(2 * np.pi) + lndet
+        )
+        npt.assert_almost_equal(
+            -logL_unnorm * 2 / len(self.lum_dists_true), 1, decimal=0
+        )
 
-        logL_low = self.likelihood.log_likelihood_lum_dist(self.lum_dists_true, estimated_scriptm=self.m_apparent_true,
-                                                           sigma_m_z=0)
+        logL_low = self.likelihood.log_likelihood_lum_dist(
+            self.lum_dists_true, estimated_scriptm=self.m_apparent_true, sigma_m_z=0
+        )
         assert logL_low < logL
 
-        logL_high = self.likelihood.log_likelihood_lum_dist(self.lum_dists_true, estimated_scriptm=self.m_apparent_true,
-                                                           sigma_m_z=self.sigma_m_true + 0.1)
+        logL_high = self.likelihood.log_likelihood_lum_dist(
+            self.lum_dists_true,
+            estimated_scriptm=self.m_apparent_true,
+            sigma_m_z=self.sigma_m_true + 0.1,
+        )
         assert logL_high < logL
 
         # check whether estimated apparent magnitude matches with the truth
-        logL_no_m = self.likelihood.log_likelihood_lum_dist(self.lum_dists_true, estimated_scriptm=None,
-                                                       sigma_m_z=self.sigma_m_true)
+        logL_no_m = self.likelihood.log_likelihood_lum_dist(
+            self.lum_dists_true, estimated_scriptm=None, sigma_m_z=self.sigma_m_true
+        )
         npt.assert_almost_equal(logL, logL_no_m, decimal=1)
 
         # check whether output with sigma_m_z=0 and =None are identical
-        logL_sigma_0 = self.likelihood.log_likelihood_lum_dist(self.lum_dists_true,
-                                                               estimated_scriptm=self.m_apparent_true, sigma_m_z=0)
-        logL_sigma_none = self.likelihood.log_likelihood_lum_dist(self.lum_dists_true,
-                                                               estimated_scriptm=self.m_apparent_true, sigma_m_z=None)
+        logL_sigma_0 = self.likelihood.log_likelihood_lum_dist(
+            self.lum_dists_true, estimated_scriptm=self.m_apparent_true, sigma_m_z=0
+        )
+        logL_sigma_none = self.likelihood.log_likelihood_lum_dist(
+            self.lum_dists_true, estimated_scriptm=self.m_apparent_true, sigma_m_z=None
+        )
         npt.assert_almost_equal(logL_sigma_0, logL_sigma_none, decimal=5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_SneLikelihood/test_sne_likelihood_from_file.py
+++ b/test/test_Likelihood/test_SneLikelihood/test_sne_likelihood_from_file.py
@@ -4,22 +4,24 @@ import os
 import numpy as np
 from astropy.cosmology import FlatLambdaCDM
 
-from hierarc.Likelihood.SneLikelihood.sne_likelihood_from_file import SneLikelihoodFromFile
+from hierarc.Likelihood.SneLikelihood.sne_likelihood_from_file import (
+    SneLikelihoodFromFile,
+)
 from hierarc.Likelihood.SneLikelihood.sne_likelihood import SneLikelihood
 
 
 class TestSneLikelihoodFromFile(object):
-
     def setup(self):
-        self.pantheon_binned_likelihood = SneLikelihoodFromFile(sample_name='Pantheon_binned')
-        self.pantheon_full_likelihood = SneLikelihoodFromFile(sample_name='Pantheon')
+        self.pantheon_binned_likelihood = SneLikelihoodFromFile(
+            sample_name="Pantheon_binned"
+        )
+        self.pantheon_full_likelihood = SneLikelihoodFromFile(sample_name="Pantheon")
         self.zcmb_bin = self.pantheon_binned_likelihood.zcmb
         self.zcmb_full = self.pantheon_full_likelihood.zcmb
         self.zhel_bin = self.pantheon_binned_likelihood.zhel
         self.zhel_full = self.pantheon_full_likelihood.zhel
 
     def test_import_pantheon(self):
-
         assert os.path.exists(self.pantheon_binned_likelihood._data_file)
         assert len(self.pantheon_binned_likelihood.zcmb) == 40
         assert len(self.pantheon_binned_likelihood.zhel) == 40
@@ -36,35 +38,54 @@ class TestSneLikelihoodFromFile(object):
 
     def test_log_likelihood_lum_dist(self):
         from astropy.cosmology import WMAP9 as cosmo
-        angular_diameter_distances = cosmo.angular_diameter_distance(self.zcmb_bin).value
-        lum_dists_binned = (5 * np.log10((1 + self.zhel_bin) * (1 + self.zcmb_bin) * angular_diameter_distances))
+
+        angular_diameter_distances = cosmo.angular_diameter_distance(
+            self.zcmb_bin
+        ).value
+        lum_dists_binned = 5 * np.log10(
+            (1 + self.zhel_bin) * (1 + self.zcmb_bin) * angular_diameter_distances
+        )
 
         # here we test some default floatings
-        logL = self.pantheon_binned_likelihood.log_likelihood_lum_dist(lum_dists_binned, estimated_scriptm=None)
+        logL = self.pantheon_binned_likelihood.log_likelihood_lum_dist(
+            lum_dists_binned, estimated_scriptm=None
+        )
         npt.assert_almost_equal(logL, -29.447965959089437, decimal=4)
 
-        angular_diameter_distances = cosmo.angular_diameter_distance(self.zcmb_full).value
-        lum_dists_full = (5 * np.log10((1 + self.zhel_full) * (1 + self.zcmb_full) * angular_diameter_distances))
-        logL = self.pantheon_full_likelihood.log_likelihood_lum_dist(lum_dists_full, estimated_scriptm=None)
+        angular_diameter_distances = cosmo.angular_diameter_distance(
+            self.zcmb_full
+        ).value
+        lum_dists_full = 5 * np.log10(
+            (1 + self.zhel_full) * (1 + self.zcmb_full) * angular_diameter_distances
+        )
+        logL = self.pantheon_full_likelihood.log_likelihood_lum_dist(
+            lum_dists_full, estimated_scriptm=None
+        )
         npt.assert_almost_equal(logL, -490.7138344241936, decimal=4)
 
         # here we use the apparent magnitude at z=0.1 as part of the likelihood. We are using the best fit value and
         # demand the same outcome as having solved for it.
         z_pivot = 0.1
         angular_diameter_distance_pivot = cosmo.angular_diameter_distance(z_pivot).value
-        lum_dist_pivot = (5 * np.log10((1 + z_pivot) * (1 + z_pivot) * angular_diameter_distance_pivot))
+        lum_dist_pivot = 5 * np.log10(
+            (1 + z_pivot) * (1 + z_pivot) * angular_diameter_distance_pivot
+        )
         apparent_mag_sne_z01 = 18.963196264371216
 
-        logL_with_mag = self.pantheon_full_likelihood.log_likelihood_lum_dist(lum_dists_full - lum_dist_pivot, estimated_scriptm=apparent_mag_sne_z01)
+        logL_with_mag = self.pantheon_full_likelihood.log_likelihood_lum_dist(
+            lum_dists_full - lum_dist_pivot, estimated_scriptm=apparent_mag_sne_z01
+        )
         npt.assert_almost_equal(logL_with_mag / logL, 1, decimal=3)
 
         # and here we test that if we change the apparent magnitude, the likelihood gets off
-        logL_with_mag = self.pantheon_full_likelihood.log_likelihood_lum_dist(lum_dists_full - lum_dist_pivot, estimated_scriptm=apparent_mag_sne_z01 + 10)
+        logL_with_mag = self.pantheon_full_likelihood.log_likelihood_lum_dist(
+            lum_dists_full - lum_dist_pivot, estimated_scriptm=apparent_mag_sne_z01 + 10
+        )
         assert logL_with_mag / logL > 20
 
     def test_log_likelihood_cosmo(self):
-        pantheon_binned_likelihood = SneLikelihood(sample_name='Pantheon_binned')
-        pantheon_full_likelihood = SneLikelihood(sample_name='Pantheon')
+        pantheon_binned_likelihood = SneLikelihood(sample_name="Pantheon_binned")
+        pantheon_full_likelihood = SneLikelihood(sample_name="Pantheon")
 
         # cosmo instance
 
@@ -73,34 +94,40 @@ class TestSneLikelihoodFromFile(object):
         om_mean, om_sigma = 0.284, 0.012
         cosmo_mean = FlatLambdaCDM(H0=70, Om0=om_mean)
         logL_mean = pantheon_binned_likelihood.log_likelihood(cosmo=cosmo_mean)
-        cosmo_sigma_plus = FlatLambdaCDM(H0=70, Om0=om_mean+om_sigma)
-        logL_sigma_plus = pantheon_binned_likelihood.log_likelihood(cosmo=cosmo_sigma_plus)
-        npt.assert_almost_equal(logL_sigma_plus - logL_mean, -1/2., decimal=1)
+        cosmo_sigma_plus = FlatLambdaCDM(H0=70, Om0=om_mean + om_sigma)
+        logL_sigma_plus = pantheon_binned_likelihood.log_likelihood(
+            cosmo=cosmo_sigma_plus
+        )
+        npt.assert_almost_equal(logL_sigma_plus - logL_mean, -1 / 2.0, decimal=1)
         cosmo_sigma_neg = FlatLambdaCDM(H0=70, Om0=om_mean - om_sigma)
-        logL_sigma_neg = pantheon_binned_likelihood.log_likelihood(cosmo=cosmo_sigma_neg)
-        npt.assert_almost_equal(logL_sigma_neg - logL_mean, -1 / 2., decimal=1)
+        logL_sigma_neg = pantheon_binned_likelihood.log_likelihood(
+            cosmo=cosmo_sigma_neg
+        )
+        npt.assert_almost_equal(logL_sigma_neg - logL_mean, -1 / 2.0, decimal=1)
 
         # for the full sample, including systematics, Scolnic et al. 2018 gets 0.298 ± 0.022 in FLCDM
         om_mean, om_sigma = 0.298, 0.022
         cosmo_mean = FlatLambdaCDM(H0=70, Om0=om_mean)
         logL_mean = pantheon_full_likelihood.log_likelihood(cosmo=cosmo_mean)
         cosmo_sigma_plus = FlatLambdaCDM(H0=70, Om0=om_mean + om_sigma)
-        logL_sigma_plus = pantheon_full_likelihood.log_likelihood(cosmo=cosmo_sigma_plus)
-        npt.assert_almost_equal(logL_sigma_plus - logL_mean, -1 / 2., decimal=1)
+        logL_sigma_plus = pantheon_full_likelihood.log_likelihood(
+            cosmo=cosmo_sigma_plus
+        )
+        npt.assert_almost_equal(logL_sigma_plus - logL_mean, -1 / 2.0, decimal=1)
         cosmo_sigma_neg = FlatLambdaCDM(H0=70, Om0=om_mean - om_sigma)
         logL_sigma_neg = pantheon_full_likelihood.log_likelihood(cosmo=cosmo_sigma_neg)
-        npt.assert_almost_equal(logL_sigma_neg - logL_mean, -1 / 2., decimal=1)
+        npt.assert_almost_equal(logL_sigma_neg - logL_mean, -1 / 2.0, decimal=1)
 
     def test_roman_forecast(self):
-        roman_binned_likelihood = SneLikelihood(sample_name='Roman_forecast')
+        roman_binned_likelihood = SneLikelihood(sample_name="Roman_forecast")
         om_mean, om_sigma = 0.284, 0.012
         cosmo_mean = FlatLambdaCDM(H0=70, Om0=om_mean)
         logL_mean = roman_binned_likelihood.log_likelihood(cosmo=cosmo_mean)
         npt.assert_almost_equal(logL_mean, -22.395743577818184, decimal=3)
 
     def test_raise(self):
-        npt.assert_raises(ValueError, SneLikelihoodFromFile, sample_name='BAD')
+        npt.assert_raises(ValueError, SneLikelihoodFromFile, sample_name="BAD")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_anisotropy_scaling.py
+++ b/test/test_Likelihood/test_anisotropy_scaling.py
@@ -1,19 +1,28 @@
 import pytest
 import numpy as np
 import unittest
-from hierarc.Likelihood.anisotropy_scaling import AnisotropyScalingSingleAperture, AnisotropyScalingIFU
+from hierarc.Likelihood.anisotropy_scaling import (
+    AnisotropyScalingSingleAperture,
+    AnisotropyScalingIFU,
+)
 
 
 class TestAnisotropyScalingSingleAperture(object):
-
     def setup(self):
         ani_param_array = np.linspace(start=0, stop=1, num=10)
         ani_scaling_array = ani_param_array * 2
-        self.scaling = AnisotropyScalingSingleAperture(ani_param_array, ani_scaling_array)
+        self.scaling = AnisotropyScalingSingleAperture(
+            ani_param_array, ani_scaling_array
+        )
 
-        ani_param_array = [np.linspace(start=0, stop=1, num=10), np.linspace(start=1, stop=2, num=5)]
+        ani_param_array = [
+            np.linspace(start=0, stop=1, num=10),
+            np.linspace(start=1, stop=2, num=5),
+        ]
         ani_scaling_array = np.outer(ani_param_array[0], ani_param_array[1])
-        self.scaling_2d = AnisotropyScalingSingleAperture(ani_param_array, ani_scaling_array)
+        self.scaling_2d = AnisotropyScalingSingleAperture(
+            ani_param_array, ani_scaling_array
+        )
 
     def test_ani_scaling(self):
         scaling = self.scaling.ani_scaling(aniso_param_array=[1])
@@ -27,17 +36,25 @@ class TestAnisotropyScalingSingleAperture(object):
 
 
 class TestAnisotropyScalingIFU(object):
-
     def setup(self):
         ani_param_array = np.linspace(start=0, stop=1, num=10)
         ani_scaling_array = ani_param_array * 2
-        self.scaling = AnisotropyScalingIFU(anisotropy_model='OM', ani_param_array=ani_param_array,
-                                            ani_scaling_array_list=[ani_scaling_array])
+        self.scaling = AnisotropyScalingIFU(
+            anisotropy_model="OM",
+            ani_param_array=ani_param_array,
+            ani_scaling_array_list=[ani_scaling_array],
+        )
 
-        ani_param_array = [np.linspace(start=0, stop=1, num=10), np.linspace(start=1, stop=2, num=5)]
+        ani_param_array = [
+            np.linspace(start=0, stop=1, num=10),
+            np.linspace(start=1, stop=2, num=5),
+        ]
         ani_scaling_array = np.outer(ani_param_array[0], ani_param_array[1])
-        self.scaling_2d = AnisotropyScalingIFU(anisotropy_model='GOM', ani_param_array=ani_param_array,
-                                            ani_scaling_array_list=[ani_scaling_array])
+        self.scaling_2d = AnisotropyScalingIFU(
+            anisotropy_model="GOM",
+            ani_param_array=ani_param_array,
+            ani_scaling_array_list=[ani_scaling_array],
+        )
 
     def test_ani_scaling(self):
         scaling = self.scaling.ani_scaling(aniso_param_array=[1])
@@ -52,49 +69,79 @@ class TestAnisotropyScalingIFU(object):
     def test_draw_anisotropy(self):
         a_ani = 1
         beta_inf = 1.5
-        param_draw = self.scaling.draw_anisotropy(a_ani=1, a_ani_sigma=0, beta_inf=beta_inf, beta_inf_sigma=0)
+        param_draw = self.scaling.draw_anisotropy(
+            a_ani=1, a_ani_sigma=0, beta_inf=beta_inf, beta_inf_sigma=0
+        )
         assert param_draw[0] == a_ani
         for i in range(100):
-            param_draw = self.scaling.draw_anisotropy(a_ani=1, a_ani_sigma=1, beta_inf=beta_inf, beta_inf_sigma=1)
+            param_draw = self.scaling.draw_anisotropy(
+                a_ani=1, a_ani_sigma=1, beta_inf=beta_inf, beta_inf_sigma=1
+            )
 
-        param_draw = self.scaling_2d.draw_anisotropy(a_ani=1, a_ani_sigma=0, beta_inf=beta_inf, beta_inf_sigma=0)
+        param_draw = self.scaling_2d.draw_anisotropy(
+            a_ani=1, a_ani_sigma=0, beta_inf=beta_inf, beta_inf_sigma=0
+        )
         assert param_draw[0] == a_ani
         assert param_draw[1] == beta_inf
         for i in range(100):
-            param_draw = self.scaling_2d.draw_anisotropy(a_ani=1, a_ani_sigma=1, beta_inf=beta_inf, beta_inf_sigma=1)
+            param_draw = self.scaling_2d.draw_anisotropy(
+                a_ani=1, a_ani_sigma=1, beta_inf=beta_inf, beta_inf_sigma=1
+            )
 
-        scaling = AnisotropyScalingIFU(anisotropy_model='NONE')
-        param_draw = scaling.draw_anisotropy(a_ani=1, a_ani_sigma=0, beta_inf=beta_inf, beta_inf_sigma=0)
+        scaling = AnisotropyScalingIFU(anisotropy_model="NONE")
+        param_draw = scaling.draw_anisotropy(
+            a_ani=1, a_ani_sigma=0, beta_inf=beta_inf, beta_inf_sigma=0
+        )
         assert param_draw is None
 
 
 class TestRaise(unittest.TestCase):
-
     def test_raise(self):
-
         with self.assertRaises(ValueError):
-            ani_param_array = [np.linspace(start=0, stop=1, num=10), np.linspace(start=1, stop=2, num=5), 1]
+            ani_param_array = [
+                np.linspace(start=0, stop=1, num=10),
+                np.linspace(start=1, stop=2, num=5),
+                1,
+            ]
             ani_scaling_array = np.outer(ani_param_array[0], ani_param_array[1])
-            self.scaling_2d = AnisotropyScalingSingleAperture(ani_param_array, ani_scaling_array)
+            self.scaling_2d = AnisotropyScalingSingleAperture(
+                ani_param_array, ani_scaling_array
+            )
 
         with self.assertRaises(ValueError):
-            AnisotropyScalingIFU(anisotropy_model='blabla', ani_param_array=np.array([0, 1]), ani_scaling_array_list=[np.array([0, 1])])
+            AnisotropyScalingIFU(
+                anisotropy_model="blabla",
+                ani_param_array=np.array([0, 1]),
+                ani_scaling_array_list=[np.array([0, 1])],
+            )
 
         with self.assertRaises(ValueError):
             ani_param_array = np.linspace(start=0, stop=1, num=10)
             ani_scaling_array = ani_param_array * 2
-            scaling = AnisotropyScalingIFU(anisotropy_model='OM', ani_param_array=ani_param_array,
-                                                ani_scaling_array_list=[ani_scaling_array])
-            scaling.draw_anisotropy(a_ani=-1, a_ani_sigma=0, beta_inf=-1, beta_inf_sigma=0)
+            scaling = AnisotropyScalingIFU(
+                anisotropy_model="OM",
+                ani_param_array=ani_param_array,
+                ani_scaling_array_list=[ani_scaling_array],
+            )
+            scaling.draw_anisotropy(
+                a_ani=-1, a_ani_sigma=0, beta_inf=-1, beta_inf_sigma=0
+            )
 
         with self.assertRaises(ValueError):
-            ani_param_array = [np.linspace(start=0, stop=1, num=10), np.linspace(start=1, stop=2, num=5)]
+            ani_param_array = [
+                np.linspace(start=0, stop=1, num=10),
+                np.linspace(start=1, stop=2, num=5),
+            ]
             ani_scaling_array = np.outer(ani_param_array[0], ani_param_array[1])
-            scaling = AnisotropyScalingIFU(anisotropy_model='GOM', ani_param_array=ani_param_array,
-                                                   ani_scaling_array_list=[ani_scaling_array])
-            scaling.draw_anisotropy(a_ani=-1, a_ani_sigma=0, beta_inf=-1, beta_inf_sigma=0)
+            scaling = AnisotropyScalingIFU(
+                anisotropy_model="GOM",
+                ani_param_array=ani_param_array,
+                ani_scaling_array_list=[ani_scaling_array],
+            )
+            scaling.draw_anisotropy(
+                a_ani=-1, a_ani_sigma=0, beta_inf=-1, beta_inf_sigma=0
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()
-

--- a/test/test_Likelihood/test_cosmo_likelihood.py
+++ b/test/test_Likelihood/test_cosmo_likelihood.py
@@ -10,7 +10,6 @@ from hierarc.Likelihood.cosmo_likelihood import CosmoLikelihood
 
 
 class TestCosmoLikelihood(object):
-
     def setup(self):
         np.random.seed(seed=41)
         self.z_L = 0.8
@@ -27,98 +26,159 @@ class TestCosmoLikelihood(object):
         num_samples = 20000
         self.ddt_samples = np.random.normal(self.D_dt_true, self.sigma_Ddt, num_samples)
         self.dd_samples = np.random.normal(self.Dd_true, self.sigma_Dd, num_samples)
-        self.kwargs_likelihood_list = [{'z_lens': self.z_L, 'z_source': self.z_S, 'likelihood_type': 'DdtDdGaussian',
-                                        'ddt_mean': self.D_dt_true, 'ddt_sigma': self.sigma_Ddt,
-                                        'dd_mean': self.Dd_true, 'dd_sigma': self.sigma_Dd}]
-        kwargs_lower_lens = {'gamma_ppn': 0, 'lambda_mst': 0}
-        kwargs_upper_lens = {'gamma_ppn': 2, 'lambda_mst': 2}
+        self.kwargs_likelihood_list = [
+            {
+                "z_lens": self.z_L,
+                "z_source": self.z_S,
+                "likelihood_type": "DdtDdGaussian",
+                "ddt_mean": self.D_dt_true,
+                "ddt_sigma": self.sigma_Ddt,
+                "dd_mean": self.Dd_true,
+                "dd_sigma": self.sigma_Dd,
+            }
+        ]
+        kwargs_lower_lens = {"gamma_ppn": 0, "lambda_mst": 0}
+        kwargs_upper_lens = {"gamma_ppn": 2, "lambda_mst": 2}
         kwargs_fixed_lens = {}
-        kwargs_lower_cosmo = {'h0': 10, 'om': 0., 'ok': -0.8, 'w': -2, 'wa': -1, 'w0': -2}
-        kwargs_upper_cosmo = {'h0': 200, 'om': 1, 'ok': 0.8, 'w': 0, 'wa': 1, 'w0': 1}
-        self.cosmology = 'oLCDM'
-        self.kwargs_bounds = {'kwargs_lower_lens': kwargs_lower_lens, 'kwargs_upper_lens': kwargs_upper_lens,
-                              'kwargs_fixed_lens': kwargs_fixed_lens,
-                              'kwargs_lower_cosmo': kwargs_lower_cosmo, 'kwargs_upper_cosmo': kwargs_upper_cosmo}
+        kwargs_lower_cosmo = {
+            "h0": 10,
+            "om": 0.0,
+            "ok": -0.8,
+            "w": -2,
+            "wa": -1,
+            "w0": -2,
+        }
+        kwargs_upper_cosmo = {"h0": 200, "om": 1, "ok": 0.8, "w": 0, "wa": 1, "w0": 1}
+        self.cosmology = "oLCDM"
+        self.kwargs_bounds = {
+            "kwargs_lower_lens": kwargs_lower_lens,
+            "kwargs_upper_lens": kwargs_upper_lens,
+            "kwargs_fixed_lens": kwargs_fixed_lens,
+            "kwargs_lower_cosmo": kwargs_lower_cosmo,
+            "kwargs_upper_cosmo": kwargs_upper_cosmo,
+        }
 
         # self.kwargs_likelihood_list = [{'z_lens': self.z_L, 'z_source': self.z_S, 'likelihood_type': 'TDKinKDE',
         #                          'dd_sample': self.dd_samples, 'ddt_sample': self.ddt_samples,
         #                          'kde_type': 'scipy_gaussian', 'bandwidth': 10}]
 
     def test_log_likelihood(self):
-        cosmoL = CosmoLikelihood(self.kwargs_likelihood_list, self.cosmology, self.kwargs_bounds, ppn_sampling=False,
-                                 lambda_mst_sampling=False, lambda_mst_distribution='delta', anisotropy_sampling=False,
-                                 anisotropy_model='OM', custom_prior=None, interpolate_cosmo=True,
-                                 num_redshift_interp=100,
-                                 cosmo_fixed=None)
+        cosmoL = CosmoLikelihood(
+            self.kwargs_likelihood_list,
+            self.cosmology,
+            self.kwargs_bounds,
+            ppn_sampling=False,
+            lambda_mst_sampling=False,
+            lambda_mst_distribution="delta",
+            anisotropy_sampling=False,
+            anisotropy_model="OM",
+            custom_prior=None,
+            interpolate_cosmo=True,
+            num_redshift_interp=100,
+            cosmo_fixed=None,
+        )
 
         def custom_prior(kwargs_cosmo, kwargs_lens, kwargs_kin, kwargs_source):
             return -1
 
-        cosmoL_prior = CosmoLikelihood(self.kwargs_likelihood_list, self.cosmology, self.kwargs_bounds,
-                                       ppn_sampling=False,
-                                       lambda_mst_sampling=False, lambda_mst_distribution='delta',
-                                       anisotropy_sampling=False,
-                                       anisotropy_model='OM', custom_prior=custom_prior, interpolate_cosmo=True,
-                                       num_redshift_interp=100,
-                                       cosmo_fixed=None)
+        cosmoL_prior = CosmoLikelihood(
+            self.kwargs_likelihood_list,
+            self.cosmology,
+            self.kwargs_bounds,
+            ppn_sampling=False,
+            lambda_mst_sampling=False,
+            lambda_mst_distribution="delta",
+            anisotropy_sampling=False,
+            anisotropy_model="OM",
+            custom_prior=custom_prior,
+            interpolate_cosmo=True,
+            num_redshift_interp=100,
+            cosmo_fixed=None,
+        )
 
-        kwargs_cosmo = {'h0': self.H0_true, 'om': self.omega_m_true, 'ok': 0}
+        kwargs_cosmo = {"h0": self.H0_true, "om": self.omega_m_true, "ok": 0}
         args = cosmoL.param.kwargs2args(kwargs_cosmo=kwargs_cosmo)
         logl = cosmoL.likelihood(args=args)
         logl_prior = cosmoL_prior.likelihood(args=args)
         npt.assert_almost_equal(logl - logl_prior, 1, decimal=8)
 
-        kwargs = {'h0': self.H0_true * 0.99, 'om': self.omega_m_true, 'ok': 0}
+        kwargs = {"h0": self.H0_true * 0.99, "om": self.omega_m_true, "ok": 0}
         args = cosmoL.param.kwargs2args(kwargs_cosmo=kwargs)
         logl_sigma = cosmoL.likelihood(args=args)
         npt.assert_almost_equal(logl - logl_sigma, 0.5, decimal=2)
 
-        kwargs = {'h0': 100, 'om': 1., 'ok': 0.1}
+        kwargs = {"h0": 100, "om": 1.0, "ok": 0.1}
         args = cosmoL.param.kwargs2args(kwargs)
         logl = cosmoL.likelihood(args=args)
         assert logl == -np.inf
 
-        kwargs = {'h0': 100, 'om': .1, 'ok': -0.6}
+        kwargs = {"h0": 100, "om": 0.1, "ok": -0.6}
         args = cosmoL.param.kwargs2args(kwargs)
         logl = cosmoL.likelihood(args=args)
         assert logl == -np.inf
 
         # outside the prior limit
-        kwargs = {'h0': 1000, 'om': .3, 'ok': -0.1}
+        kwargs = {"h0": 1000, "om": 0.3, "ok": -0.1}
         args = cosmoL.param.kwargs2args(kwargs)
         logl = cosmoL.likelihood(args=args)
         assert logl == -np.inf
 
     def test_cosmo_instance(self):
-        kwargs_cosmo = {'h0': 100, 'om': .1, 'ok': -0.1}
-        cosmoL = CosmoLikelihood(self.kwargs_likelihood_list, self.cosmology, self.kwargs_bounds,
-                                 interpolate_cosmo=False, cosmo_fixed=None)
+        kwargs_cosmo = {"h0": 100, "om": 0.1, "ok": -0.1}
+        cosmoL = CosmoLikelihood(
+            self.kwargs_likelihood_list,
+            self.cosmology,
+            self.kwargs_bounds,
+            interpolate_cosmo=False,
+            cosmo_fixed=None,
+        )
         cosmo_astropy = cosmoL.cosmo_instance(kwargs_cosmo)
 
-        cosmoL = CosmoLikelihood(self.kwargs_likelihood_list, self.cosmology, self.kwargs_bounds,
-                                 interpolate_cosmo=True,
-                                 num_redshift_interp=100, cosmo_fixed=None)
+        cosmoL = CosmoLikelihood(
+            self.kwargs_likelihood_list,
+            self.cosmology,
+            self.kwargs_bounds,
+            interpolate_cosmo=True,
+            num_redshift_interp=100,
+            cosmo_fixed=None,
+        )
         cosmo_interp = cosmoL.cosmo_instance(kwargs_cosmo)
 
-        cosmoL = CosmoLikelihood(self.kwargs_likelihood_list, self.cosmology, self.kwargs_bounds,
-                                 interpolate_cosmo=True,
-                                 num_redshift_interp=100, cosmo_fixed=cosmo_astropy)
-        kwargs_cosmo_wrong = {'h0': 10, 'om': .3, 'ok': 0}
+        cosmoL = CosmoLikelihood(
+            self.kwargs_likelihood_list,
+            self.cosmology,
+            self.kwargs_bounds,
+            interpolate_cosmo=True,
+            num_redshift_interp=100,
+            cosmo_fixed=cosmo_astropy,
+        )
+        kwargs_cosmo_wrong = {"h0": 10, "om": 0.3, "ok": 0}
         cosmo_fixed_interp = cosmoL.cosmo_instance(kwargs_cosmo_wrong)
 
-        cosmoL = CosmoLikelihood(self.kwargs_likelihood_list, self.cosmology, self.kwargs_bounds,
-                                 interpolate_cosmo=False,
-                                 num_redshift_interp=100, cosmo_fixed=cosmo_astropy)
-        kwargs_cosmo_wrong = {'h0': 10, 'om': .3, 'ok': 0}
+        cosmoL = CosmoLikelihood(
+            self.kwargs_likelihood_list,
+            self.cosmology,
+            self.kwargs_bounds,
+            interpolate_cosmo=False,
+            num_redshift_interp=100,
+            cosmo_fixed=cosmo_astropy,
+        )
+        kwargs_cosmo_wrong = {"h0": 10, "om": 0.3, "ok": 0}
         cosmo_fixed = cosmoL.cosmo_instance(kwargs_cosmo_wrong)
 
         # and here we inject pre-computed angular diameter distances as a function of redshift
         redshifts = np.linspace(start=0, stop=5, num=100)
         ang_diameter_distances = cosmo_astropy.angular_diameter_distance(redshifts)
-        Ok0 = kwargs_cosmo['ok']
-        K = cosmo_interp.k  # compute the curvature from the interpolation class (as easily available)
-        kwargs_cosmo_interp = {'ang_diameter_distances': ang_diameter_distances,
-                               'redshifts': redshifts, 'ok': Ok0, 'K': K}
+        Ok0 = kwargs_cosmo["ok"]
+        K = (
+            cosmo_interp.k
+        )  # compute the curvature from the interpolation class (as easily available)
+        kwargs_cosmo_interp = {
+            "ang_diameter_distances": ang_diameter_distances,
+            "redshifts": redshifts,
+            "ok": Ok0,
+            "K": K,
+        }
 
         cosmo_interp_input = cosmoL.cosmo_instance(kwargs_cosmo_interp)
 
@@ -135,29 +195,57 @@ class TestCosmoLikelihood(object):
         npt.assert_almost_equal(dd_astropy, dd_fixed_interp, decimal=1)
 
     def test_oLCDM_init(self):
-        kwargs_cosmo = {'h0': 100, 'om': .1, 'ok': -0.1}
-        kwargs_likelihood_list = [{'likelihood_type': 'DSPL', 'z_lens': 0.3, 'z_source_1': 0.5, 'z_source_2':1.5,
-                                   'beta_dspl': 1.2, 'sigma_beta_dspl': 0.01}]
-        cosmoL = CosmoLikelihood(kwargs_likelihood_list, self.cosmology, self.kwargs_bounds,
-                                 interpolate_cosmo=False, cosmo_fixed=None)
+        kwargs_cosmo = {"h0": 100, "om": 0.1, "ok": -0.1}
+        kwargs_likelihood_list = [
+            {
+                "likelihood_type": "DSPL",
+                "z_lens": 0.3,
+                "z_source_1": 0.5,
+                "z_source_2": 1.5,
+                "beta_dspl": 1.2,
+                "sigma_beta_dspl": 0.01,
+            }
+        ]
+        cosmoL = CosmoLikelihood(
+            kwargs_likelihood_list,
+            self.cosmology,
+            self.kwargs_bounds,
+            interpolate_cosmo=False,
+            cosmo_fixed=None,
+        )
 
     def test_sne_likelihood_integration(self):
-        cosmoL = CosmoLikelihood([], self.cosmology, self.kwargs_bounds, sne_likelihood='Pantheon_binned',
-                                 interpolate_cosmo=True, num_redshift_interp=100, cosmo_fixed=None)
-        kwargs_cosmo = {'h0': self.H0_true, 'om': self.omega_m_true, 'ok': 0}
+        cosmoL = CosmoLikelihood(
+            [],
+            self.cosmology,
+            self.kwargs_bounds,
+            sne_likelihood="Pantheon_binned",
+            interpolate_cosmo=True,
+            num_redshift_interp=100,
+            cosmo_fixed=None,
+        )
+        kwargs_cosmo = {"h0": self.H0_true, "om": self.omega_m_true, "ok": 0}
         args = cosmoL.param.kwargs2args(kwargs_cosmo=kwargs_cosmo)
         logl = cosmoL.likelihood(args=args)
         assert logl < 0
 
     def test_kde_likelihood_integration(self):
-        chain = import_Planck_chain(_PATH_2_PLANCKDATA, 'base', 'plikHM_TTTEEE_lowl_lowE', ['h0', 'om'],
-                                    self.cosmology, rescale=True)
-        cosmoL = CosmoLikelihood([], 'FLCDM', self.kwargs_bounds, KDE_likelihood_chain=chain)
-        kwargs_cosmo = {'h0': self.H0_true, 'om': self.omega_m_true, 'ok': 0}
+        chain = import_Planck_chain(
+            _PATH_2_PLANCKDATA,
+            "base",
+            "plikHM_TTTEEE_lowl_lowE",
+            ["h0", "om"],
+            self.cosmology,
+            rescale=True,
+        )
+        cosmoL = CosmoLikelihood(
+            [], "FLCDM", self.kwargs_bounds, KDE_likelihood_chain=chain
+        )
+        kwargs_cosmo = {"h0": self.H0_true, "om": self.omega_m_true, "ok": 0}
         args = cosmoL.param.kwargs2args(kwargs_cosmo=kwargs_cosmo)
         logl = cosmoL.likelihood(args=args)
         assert logl < 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_hierarchy_likelihood.py
+++ b/test/test_Likelihood/test_hierarchy_likelihood.py
@@ -6,7 +6,6 @@ import numpy.testing as npt
 
 
 class TestLensLikelihood(object):
-
     def setup(self):
         z_lens = 0.5
         z_source = 1.5
@@ -14,57 +13,128 @@ class TestLensLikelihood(object):
         dd = self.cosmo.angular_diameter_distance(z=z_lens).value
         ds = self.cosmo.angular_diameter_distance(z=z_source).value
         dds = self.cosmo.angular_diameter_distance_z1z2(z1=z_lens, z2=z_source).value
-        ddt = (1. + z_lens) * dd * ds / dds
+        ddt = (1.0 + z_lens) * dd * ds / dds
 
         ani_param_array = np.linspace(start=0, stop=5, num=10)
         ani_scaling_array = ani_param_array
 
-        kwargs_likelihood = {'ddt_mean': ddt, 'ddt_sigma': ddt/20, 'dd_mean': dd, 'dd_sigma': dd/10}
-        self.likelihood = LensLikelihood(z_lens, z_source, name='name', likelihood_type='DdtDdGaussian',
-                                    anisotropy_model='OM', ani_param_array=ani_param_array, ani_scaling_array_list=None,
-                                    ani_scaling_array=ani_scaling_array, num_distribution_draws=200, kappa_ext_bias=True,
-                                    kappa_pdf=None, kappa_bin_edges=None, mst_ifu=True, **kwargs_likelihood)
-        self.likelihood_single = LensLikelihood(z_lens, z_source, name='name', likelihood_type='DdtDdGaussian',
-                                    anisotropy_model='OM', ani_param_array=ani_param_array, ani_scaling_array_list=None,
-                                    ani_scaling_array=ani_scaling_array, num_distribution_draws=200, kappa_ext_bias=False,
-                                    kappa_pdf=None, kappa_bin_edges=None, mst_ifu=False, **kwargs_likelihood)
-        self.likelihood_zero_dist = LensLikelihood(z_lens, z_source, name='name', likelihood_type='DdtDdGaussian',
-                                    anisotropy_model='OM', ani_param_array=ani_param_array, ani_scaling_array_list=None,
-                                    ani_scaling_array=ani_scaling_array, num_distribution_draws=0, kappa_ext_bias=True,
-                                    kappa_pdf=None, kappa_bin_edges=None, mst_ifu=True, **kwargs_likelihood)
+        kwargs_likelihood = {
+            "ddt_mean": ddt,
+            "ddt_sigma": ddt / 20,
+            "dd_mean": dd,
+            "dd_sigma": dd / 10,
+        }
+        self.likelihood = LensLikelihood(
+            z_lens,
+            z_source,
+            name="name",
+            likelihood_type="DdtDdGaussian",
+            anisotropy_model="OM",
+            ani_param_array=ani_param_array,
+            ani_scaling_array_list=None,
+            ani_scaling_array=ani_scaling_array,
+            num_distribution_draws=200,
+            kappa_ext_bias=True,
+            kappa_pdf=None,
+            kappa_bin_edges=None,
+            mst_ifu=True,
+            **kwargs_likelihood
+        )
+        self.likelihood_single = LensLikelihood(
+            z_lens,
+            z_source,
+            name="name",
+            likelihood_type="DdtDdGaussian",
+            anisotropy_model="OM",
+            ani_param_array=ani_param_array,
+            ani_scaling_array_list=None,
+            ani_scaling_array=ani_scaling_array,
+            num_distribution_draws=200,
+            kappa_ext_bias=False,
+            kappa_pdf=None,
+            kappa_bin_edges=None,
+            mst_ifu=False,
+            **kwargs_likelihood
+        )
+        self.likelihood_zero_dist = LensLikelihood(
+            z_lens,
+            z_source,
+            name="name",
+            likelihood_type="DdtDdGaussian",
+            anisotropy_model="OM",
+            ani_param_array=ani_param_array,
+            ani_scaling_array_list=None,
+            ani_scaling_array=ani_scaling_array,
+            num_distribution_draws=0,
+            kappa_ext_bias=True,
+            kappa_pdf=None,
+            kappa_bin_edges=None,
+            mst_ifu=True,
+            **kwargs_likelihood
+        )
 
         kappa_posterior = np.random.normal(loc=0, scale=0.03, size=100000)
         kappa_pdf, kappa_bin_edges = np.histogram(kappa_posterior, density=True)
-        self.likelihood_kappa_ext = LensLikelihood(z_lens, z_source, name='name', likelihood_type='DdtDdGaussian',
-                                         anisotropy_model='OM', ani_param_array=ani_param_array,
-                                         ani_scaling_array_list=None,
-                                         ani_scaling_array=ani_scaling_array, num_distribution_draws=200,
-                                         kappa_ext_bias=True,
-                                         kappa_pdf=kappa_pdf, kappa_bin_edges=kappa_bin_edges, mst_ifu=False, **kwargs_likelihood)
+        self.likelihood_kappa_ext = LensLikelihood(
+            z_lens,
+            z_source,
+            name="name",
+            likelihood_type="DdtDdGaussian",
+            anisotropy_model="OM",
+            ani_param_array=ani_param_array,
+            ani_scaling_array_list=None,
+            ani_scaling_array=ani_scaling_array,
+            num_distribution_draws=200,
+            kappa_ext_bias=True,
+            kappa_pdf=kappa_pdf,
+            kappa_bin_edges=kappa_bin_edges,
+            mst_ifu=False,
+            **kwargs_likelihood
+        )
 
     def test_lens_log_likelihood(self):
         np.random.seed(42)
-        kwargs_lens = {'lambda_mst': 1, 'lambda_mst_sigma': 0.01, 'kappa_ext': 0, 'kappa_ext_sigma': 0.03,
-                       'lambda_ifu': 1, 'lambda_ifu_sigma': 0.01}
-        kwargs_kin = {'a_ani': 1, 'a_ani_sigma': 0.1}
-        ln_likelihood = self.likelihood.lens_log_likelihood(self.cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin)
+        kwargs_lens = {
+            "lambda_mst": 1,
+            "lambda_mst_sigma": 0.01,
+            "kappa_ext": 0,
+            "kappa_ext_sigma": 0.03,
+            "lambda_ifu": 1,
+            "lambda_ifu_sigma": 0.01,
+        }
+        kwargs_kin = {"a_ani": 1, "a_ani_sigma": 0.1}
+        ln_likelihood = self.likelihood.lens_log_likelihood(
+            self.cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin
+        )
         npt.assert_almost_equal(ln_likelihood, -0.5, decimal=1)
 
-        ln_likelihood_zero = self.likelihood_zero_dist.lens_log_likelihood(self.cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin)
+        ln_likelihood_zero = self.likelihood_zero_dist.lens_log_likelihood(
+            self.cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin
+        )
         assert ln_likelihood_zero == -np.inf
 
-        ln_likelihood_kappa_ext = self.likelihood_kappa_ext.lens_log_likelihood(self.cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin)
+        ln_likelihood_kappa_ext = self.likelihood_kappa_ext.lens_log_likelihood(
+            self.cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin
+        )
         npt.assert_almost_equal(ln_likelihood, ln_likelihood_kappa_ext, decimal=1)
 
-        kwargs_lens = {'lambda_mst': 1000000, 'lambda_mst_sigma': 0, 'kappa_ext': 0, 'kappa_ext_sigma': 0,
-                       'lambda_ifu': 1, 'lambda_ifu_sigma': 0}
-        kwargs_kin = {'a_ani': 1, 'a_ani_sigma': 0}
-        ln_inf = self.likelihood_single.lens_log_likelihood(self.cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin)
+        kwargs_lens = {
+            "lambda_mst": 1000000,
+            "lambda_mst_sigma": 0,
+            "kappa_ext": 0,
+            "kappa_ext_sigma": 0,
+            "lambda_ifu": 1,
+            "lambda_ifu_sigma": 0,
+        }
+        kwargs_kin = {"a_ani": 1, "a_ani_sigma": 0}
+        ln_inf = self.likelihood_single.lens_log_likelihood(
+            self.cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin
+        )
         assert ln_inf < -10000000
 
         kwargs_test = self.likelihood._kwargs_init(kwargs=None)
         assert type(kwargs_test) is dict
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_lens_sample_likelihood.py
+++ b/test/test_Likelihood/test_lens_sample_likelihood.py
@@ -4,11 +4,12 @@ import numpy.testing as npt
 from lenstronomy.Cosmo.lens_cosmo import LensCosmo
 from hierarc.Likelihood.lens_sample_likelihood import LensSampleLikelihood
 from astropy.cosmology import FlatLambdaCDM
-from hierarc.Likelihood.LensLikelihood.double_source_plane import beta_double_source_plane
+from hierarc.Likelihood.LensLikelihood.double_source_plane import (
+    beta_double_source_plane,
+)
 
 
 class TestLensLikelihood(object):
-
     def setup(self):
         np.random.seed(seed=41)
         self.z_L = 0.8
@@ -24,24 +25,44 @@ class TestLensLikelihood(object):
         self.sigma_Dd = 100
         self.sigma_Ddt = 100
         num_samples = 10000
-        self.D_dt_samples = np.random.normal(self.D_dt_true, self.sigma_Ddt, num_samples)
+        self.D_dt_samples = np.random.normal(
+            self.D_dt_true, self.sigma_Ddt, num_samples
+        )
         self.D_d_samples = np.random.normal(self.Dd_true, self.sigma_Dd, num_samples)
         ani_param_array = np.linspace(0, 2, 10)
         ani_scaling_array = np.ones_like(ani_param_array)
-        self.kwargs_lens_list = [{'z_lens': self.z_L, 'z_source': self.z_S, 'likelihood_type': 'DdtDdKDE',
-                                  'dd_samples': self.D_d_samples, 'ddt_samples': self.D_dt_samples,
-                                  'kde_type': 'scipy_gaussian', 'bandwidth': 1},
-                                 {'z_lens': self.z_L, 'z_source': self.z_S, 'likelihood_type': 'DsDdsGaussian',
-                                  'ds_dds_mean': lensCosmo.ds/lensCosmo.dds, 'ds_dds_sigma': 1,
-                                  'ani_param_array': ani_param_array, 'ani_scaling_array': ani_scaling_array}]
+        self.kwargs_lens_list = [
+            {
+                "z_lens": self.z_L,
+                "z_source": self.z_S,
+                "likelihood_type": "DdtDdKDE",
+                "dd_samples": self.D_d_samples,
+                "ddt_samples": self.D_dt_samples,
+                "kde_type": "scipy_gaussian",
+                "bandwidth": 1,
+            },
+            {
+                "z_lens": self.z_L,
+                "z_source": self.z_S,
+                "likelihood_type": "DsDdsGaussian",
+                "ds_dds_mean": lensCosmo.ds / lensCosmo.dds,
+                "ds_dds_sigma": 1,
+                "ani_param_array": ani_param_array,
+                "ani_scaling_array": ani_scaling_array,
+            },
+        ]
         self.likelihood = LensSampleLikelihood(kwargs_lens_list=self.kwargs_lens_list)
 
     def test_log_likelihood(self):
-        kwargs_lens = {'kappa_ext': 0, 'gamma_ppn': 1}
-        kwargs_kin = {'a_ani': 1}
-        logl = self.likelihood.log_likelihood(self.cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin)
-        cosmo = FlatLambdaCDM(H0=self.H0_true*0.99, Om0=self.omega_m_true, Ob0=0.05)
-        logl_sigma = self.likelihood.log_likelihood(cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin)
+        kwargs_lens = {"kappa_ext": 0, "gamma_ppn": 1}
+        kwargs_kin = {"a_ani": 1}
+        logl = self.likelihood.log_likelihood(
+            self.cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin
+        )
+        cosmo = FlatLambdaCDM(H0=self.H0_true * 0.99, Om0=self.omega_m_true, Ob0=0.05)
+        logl_sigma = self.likelihood.log_likelihood(
+            cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin
+        )
         npt.assert_almost_equal(logl - logl_sigma, 0.12, decimal=2)
 
     def test_num_data(self):
@@ -53,16 +74,25 @@ class TestLensLikelihood(object):
         zl = 0.5
         zs1 = 1
         zs2 = 2
-        beta = beta_double_source_plane(z_lens=zl, z_source_1=zs1, z_source_2=zs2, cosmo=cosmo)
+        beta = beta_double_source_plane(
+            z_lens=zl, z_source_1=zs1, z_source_2=zs2, cosmo=cosmo
+        )
         sigma_beta = 0.1
 
-        kwargs_lens_list = [{'z_lens': zl, 'z_source_1': zs1, 'z_source_2': zs2,
-                             'beta_dspl': beta, 'sigma_beta_dspl': sigma_beta,
-                             'likelihood_type': 'DSPL'}]
+        kwargs_lens_list = [
+            {
+                "z_lens": zl,
+                "z_source_1": zs1,
+                "z_source_2": zs2,
+                "beta_dspl": beta,
+                "sigma_beta_dspl": sigma_beta,
+                "likelihood_type": "DSPL",
+            }
+        ]
         likelihood = LensSampleLikelihood(kwargs_lens_list=kwargs_lens_list)
         log_l = likelihood.log_likelihood(cosmo=cosmo)
         npt.assert_almost_equal(log_l, 0, decimal=5)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Likelihood/test_transform_cosmography.py
+++ b/test/test_Likelihood/test_transform_cosmography.py
@@ -5,48 +5,73 @@ import numpy.testing as npt
 
 
 class TestTransformedCoismography(object):
-
     def setup(self):
         z_lens = 0.5
         z_source = 1.5
         self.transform = TransformedCosmography(z_lens=z_lens, z_source=z_source)
 
     def test_displace_prediction(self):
-
         ddt, dd = 1, 1
         mag_source = 16
         magnitude_zero_point = 20
-        amp_source = magnitude2cps(magnitude=mag_source, magnitude_zero_point=magnitude_zero_point)
+        amp_source = magnitude2cps(
+            magnitude=mag_source, magnitude_zero_point=magnitude_zero_point
+        )
         # case where nothing happens
-        ddt_, dd_, mag_source_ = self.transform.displace_prediction(ddt, dd, gamma_ppn=1, lambda_mst=1, kappa_ext=0,
-                                                                    mag_source=mag_source)
+        ddt_, dd_, mag_source_ = self.transform.displace_prediction(
+            ddt, dd, gamma_ppn=1, lambda_mst=1, kappa_ext=0, mag_source=mag_source
+        )
         assert ddt == ddt_
         assert dd == dd_
         assert mag_source_ == mag_source
 
         # case where kappa_ext is displaced
         kappa_ext = 0.1
-        ddt_, dd_, mag_source_ = self.transform.displace_prediction(ddt, dd, gamma_ppn=1, lambda_mst=1,
-                                                                    kappa_ext=kappa_ext, mag_source=mag_source)
+        ddt_, dd_, mag_source_ = self.transform.displace_prediction(
+            ddt,
+            dd,
+            gamma_ppn=1,
+            lambda_mst=1,
+            kappa_ext=kappa_ext,
+            mag_source=mag_source,
+        )
         assert ddt_ == ddt * (1 - kappa_ext)
         assert dd_ == dd
-        amp_source_ = magnitude2cps(magnitude=mag_source_, magnitude_zero_point=magnitude_zero_point)
-        npt.assert_almost_equal(amp_source_, amp_source / (1 - kappa_ext)**2, decimal=7)
+        amp_source_ = magnitude2cps(
+            magnitude=mag_source_, magnitude_zero_point=magnitude_zero_point
+        )
+        npt.assert_almost_equal(
+            amp_source_, amp_source / (1 - kappa_ext) ** 2, decimal=7
+        )
 
         # case where lambda_mst is displaced
         lambda_mst = 0.9
-        ddt_, dd_, mag_source_ = self.transform.displace_prediction(ddt, dd, gamma_ppn=1, lambda_mst=lambda_mst,
-                                                                    kappa_ext=0, mag_source=mag_source)
+        ddt_, dd_, mag_source_ = self.transform.displace_prediction(
+            ddt,
+            dd,
+            gamma_ppn=1,
+            lambda_mst=lambda_mst,
+            kappa_ext=0,
+            mag_source=mag_source,
+        )
         assert ddt_ == ddt * lambda_mst
         assert dd == dd_
-        amp_source_ = magnitude2cps(magnitude=mag_source_, magnitude_zero_point=magnitude_zero_point)
-        npt.assert_almost_equal(amp_source_, amp_source / lambda_mst ** 2, decimal=7)
+        amp_source_ = magnitude2cps(
+            magnitude=mag_source_, magnitude_zero_point=magnitude_zero_point
+        )
+        npt.assert_almost_equal(amp_source_, amp_source / lambda_mst**2, decimal=7)
         # case for gamma_ppn
         gamma_ppn = 1.1
-        ddt_, dd_, mag_source_ = self.transform.displace_prediction(ddt, dd, gamma_ppn=gamma_ppn, lambda_mst=1,
-                                                                    kappa_ext=0, mag_source=mag_source)
+        ddt_, dd_, mag_source_ = self.transform.displace_prediction(
+            ddt,
+            dd,
+            gamma_ppn=gamma_ppn,
+            lambda_mst=1,
+            kappa_ext=0,
+            mag_source=mag_source,
+        )
         assert ddt_ == ddt
-        assert dd_ == dd * (1 + gamma_ppn) / 2.
+        assert dd_ == dd * (1 + gamma_ppn) / 2.0
         assert mag_source_ == mag_source
 
     def test_displace_kappa_ext(self):
@@ -57,5 +82,5 @@ class TestTransformedCoismography(object):
         assert dd == dd_
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Sampling/test_ParamManager/test_cosmo_param.py
+++ b/test/test_Sampling/test_ParamManager/test_cosmo_param.py
@@ -5,19 +5,36 @@ import unittest
 
 
 class TestCosmoParamFLCDM(object):
-
     def setup(self):
-        cosmology_list = ['FLCDM', "FwCDM", "w0waCDM", "oLCDM", "NONE"]
-        kwargs_fixed = {'h0': 70, 'om': 0.3, 'ok': 0., 'w': -1, 'wa': -0, 'w0': -0, 'gamma_ppn': 1}
+        cosmology_list = ["FLCDM", "FwCDM", "w0waCDM", "oLCDM", "NONE"]
+        kwargs_fixed = {
+            "h0": 70,
+            "om": 0.3,
+            "ok": 0.0,
+            "w": -1,
+            "wa": -0,
+            "w0": -0,
+            "gamma_ppn": 1,
+        }
         self._param_list = []
         self._param_list_fixed = []
         for cosmology in cosmology_list:
-            self._param_list.append(CosmoParam(cosmology, ppn_sampling=True, kwargs_fixed=None))
-            self._param_list_fixed.append(CosmoParam(cosmology, ppn_sampling=True, kwargs_fixed=kwargs_fixed))
+            self._param_list.append(
+                CosmoParam(cosmology, ppn_sampling=True, kwargs_fixed=None)
+            )
+            self._param_list_fixed.append(
+                CosmoParam(cosmology, ppn_sampling=True, kwargs_fixed=kwargs_fixed)
+            )
         self.cosmology_list = cosmology_list
 
     def test_param_list(self):
-        num_param_list = [3, 4, 5, 4, 1]  # number of parameters for the cosmological models cosmology_list
+        num_param_list = [
+            3,
+            4,
+            5,
+            4,
+            1,
+        ]  # number of parameters for the cosmological models cosmology_list
         for i, param in enumerate(self._param_list):
             param_list = param.param_list(latex_style=False)
             assert len(param_list) == num_param_list[i]
@@ -30,7 +47,15 @@ class TestCosmoParamFLCDM(object):
             assert len(param_list) == 0
 
     def test_args2kwargs(self):
-        kwargs = {'h0': 70, 'om': 0.3, 'ok': 0., 'w': -1, 'wa': -0, 'w0': -0, 'gamma_ppn': 1}
+        kwargs = {
+            "h0": 70,
+            "om": 0.3,
+            "ok": 0.0,
+            "w": -1,
+            "wa": -0,
+            "w0": -0,
+            "gamma_ppn": 1,
+        }
         for i, param in enumerate(self._param_list):
             args = param.kwargs2args(kwargs)
             kwargs_new, i = param.args2kwargs(args, i=0)
@@ -43,23 +68,37 @@ class TestCosmoParamFLCDM(object):
             npt.assert_almost_equal(args_new, args)
 
     def test_cosmo(self):
-        kwargs_cosmo = {'h0': 70, 'om': 0.3, 'ok': 0., 'w': -1, 'wa': -0, 'w0': -0, 'gamma_ppn': 1}
+        kwargs_cosmo = {
+            "h0": 70,
+            "om": 0.3,
+            "ok": 0.0,
+            "w": -1,
+            "wa": -0,
+            "w0": -0,
+            "gamma_ppn": 1,
+        }
         for i, param in enumerate(self._param_list):
             cosmo = param.cosmo(kwargs_cosmo)
             if self.cosmology_list[i] != "NONE":
-                assert hasattr(cosmo, 'H0')
+                assert hasattr(cosmo, "H0")
 
 
 class TestRaise(unittest.TestCase):
-
     def test_raise(self):
-
         with self.assertRaises(ValueError):
-            param = CosmoParam(cosmology='FLCDM', ppn_sampling=True, kwargs_fixed={})
-            param._cosmology = 'bad'
-            kwargs_cosmo = {'h0': 70, 'om': 0.3, 'ok': 0., 'w': -1, 'wa': -0, 'w0': -0, 'gamma_ppn': 1}
+            param = CosmoParam(cosmology="FLCDM", ppn_sampling=True, kwargs_fixed={})
+            param._cosmology = "bad"
+            kwargs_cosmo = {
+                "h0": 70,
+                "om": 0.3,
+                "ok": 0.0,
+                "w": -1,
+                "wa": -0,
+                "w0": -0,
+                "gamma_ppn": 1,
+            }
             param.cosmo(kwargs_cosmo)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Sampling/test_ParamManager/test_kin_param.py
+++ b/test/test_Sampling/test_ParamManager/test_kin_param.py
@@ -4,18 +4,38 @@ import pytest
 
 
 class TestKinParam(object):
-
     def setup(self):
-        self._param = KinParam(anisotropy_sampling=True, anisotropy_model='GOM', distribution_function='GAUSSIAN',
-                 sigma_v_systematics=True, kwargs_fixed={})
+        self._param = KinParam(
+            anisotropy_sampling=True,
+            anisotropy_model="GOM",
+            distribution_function="GAUSSIAN",
+            sigma_v_systematics=True,
+            kwargs_fixed={},
+        )
 
-        self._param_log_scatter = KinParam(anisotropy_sampling=True, anisotropy_model='GOM', distribution_function='GAUSSIAN',
-                               sigma_v_systematics=True, log_scatter=True, kwargs_fixed={})
+        self._param_log_scatter = KinParam(
+            anisotropy_sampling=True,
+            anisotropy_model="GOM",
+            distribution_function="GAUSSIAN",
+            sigma_v_systematics=True,
+            log_scatter=True,
+            kwargs_fixed={},
+        )
 
-        kwargs_fixed = {'a_ani': 1, 'a_ani_sigma': 0.1, 'beta_inf': 1., 'beta_inf_sigma': 0.2,
-                        'sigma_v_sys_error': 0.05}
-        self._param_fixed = KinParam(anisotropy_sampling=True, anisotropy_model='GOM', distribution_function='GAUSSIAN',
-                                     sigma_v_systematics=True, kwargs_fixed=kwargs_fixed)
+        kwargs_fixed = {
+            "a_ani": 1,
+            "a_ani_sigma": 0.1,
+            "beta_inf": 1.0,
+            "beta_inf_sigma": 0.2,
+            "sigma_v_sys_error": 0.05,
+        }
+        self._param_fixed = KinParam(
+            anisotropy_sampling=True,
+            anisotropy_model="GOM",
+            distribution_function="GAUSSIAN",
+            sigma_v_systematics=True,
+            kwargs_fixed=kwargs_fixed,
+        )
 
     def test_param_list(self):
         param_list = self._param.param_list(latex_style=False)
@@ -34,7 +54,13 @@ class TestKinParam(object):
         assert len(param_list) == 0
 
     def test_args2kwargs(self):
-        kwargs = {'a_ani': 1, 'a_ani_sigma': 0.1, 'beta_inf': 1., 'beta_inf_sigma': 0.2, 'sigma_v_sys_error': 0.05}
+        kwargs = {
+            "a_ani": 1,
+            "a_ani_sigma": 0.1,
+            "beta_inf": 1.0,
+            "beta_inf_sigma": 0.2,
+            "sigma_v_sys_error": 0.05,
+        }
         args = self._param.kwargs2args(kwargs)
         kwargs_new, i = self._param.args2kwargs(args, i=0)
         args_new = self._param.kwargs2args(kwargs_new)
@@ -51,5 +77,5 @@ class TestKinParam(object):
         npt.assert_almost_equal(args_new, args)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Sampling/test_ParamManager/test_lens_param.py
+++ b/test/test_Sampling/test_ParamManager/test_lens_param.py
@@ -3,21 +3,52 @@ import numpy.testing as npt
 
 
 class TestLensParam(object):
-
     def setup(self):
-        self._param = LensParam(lambda_mst_sampling=True, lambda_mst_distribution='GAUSSIAN', kappa_ext_sampling=True,
-                 kappa_ext_distribution='GAUSSIAN', lambda_ifu_sampling=True, lambda_ifu_distribution='GAUSSIAN',
-                                alpha_lambda_sampling=True, beta_lambda_sampling=True,  kwargs_fixed={})
+        self._param = LensParam(
+            lambda_mst_sampling=True,
+            lambda_mst_distribution="GAUSSIAN",
+            kappa_ext_sampling=True,
+            kappa_ext_distribution="GAUSSIAN",
+            lambda_ifu_sampling=True,
+            lambda_ifu_distribution="GAUSSIAN",
+            alpha_lambda_sampling=True,
+            beta_lambda_sampling=True,
+            kwargs_fixed={},
+        )
 
-        kwargs_fixed = {'lambda_mst': 1, 'lambda_mst_sigma': 0.1, 'lambda_ifu': 1.1, 'lambda_ifu_sigma': 0.2,
-                        'kappa_ext': 0.01, 'kappa_ext_sigma': 0.03, 'alpha_lambda': 0, 'beta_lambda': 0 }
-        self._param_fixed = LensParam(lambda_mst_sampling=True, lambda_mst_distribution='GAUSSIAN', kappa_ext_sampling=True,
-                                kappa_ext_distribution='GAUSSIAN', lambda_ifu_sampling=True,
-                                lambda_ifu_distribution='GAUSSIAN', alpha_lambda_sampling=True, beta_lambda_sampling=True,
-                                kwargs_fixed=kwargs_fixed)
-        self._param_log_scatter = LensParam(lambda_mst_sampling=True, lambda_mst_distribution='GAUSSIAN', kappa_ext_sampling=True,
-                 kappa_ext_distribution='GAUSSIAN', lambda_ifu_sampling=True, lambda_ifu_distribution='GAUSSIAN',
-                                alpha_lambda_sampling=True, beta_lambda_sampling=True, log_scatter=True, kwargs_fixed={})
+        kwargs_fixed = {
+            "lambda_mst": 1,
+            "lambda_mst_sigma": 0.1,
+            "lambda_ifu": 1.1,
+            "lambda_ifu_sigma": 0.2,
+            "kappa_ext": 0.01,
+            "kappa_ext_sigma": 0.03,
+            "alpha_lambda": 0,
+            "beta_lambda": 0,
+        }
+        self._param_fixed = LensParam(
+            lambda_mst_sampling=True,
+            lambda_mst_distribution="GAUSSIAN",
+            kappa_ext_sampling=True,
+            kappa_ext_distribution="GAUSSIAN",
+            lambda_ifu_sampling=True,
+            lambda_ifu_distribution="GAUSSIAN",
+            alpha_lambda_sampling=True,
+            beta_lambda_sampling=True,
+            kwargs_fixed=kwargs_fixed,
+        )
+        self._param_log_scatter = LensParam(
+            lambda_mst_sampling=True,
+            lambda_mst_distribution="GAUSSIAN",
+            kappa_ext_sampling=True,
+            kappa_ext_distribution="GAUSSIAN",
+            lambda_ifu_sampling=True,
+            lambda_ifu_distribution="GAUSSIAN",
+            alpha_lambda_sampling=True,
+            beta_lambda_sampling=True,
+            log_scatter=True,
+            kwargs_fixed={},
+        )
 
     def test_param_list(self):
         param_list = self._param.param_list(latex_style=False)
@@ -36,8 +67,16 @@ class TestLensParam(object):
         assert len(param_list) == 0
 
     def test_args2kwargs(self):
-        kwargs = {'lambda_mst': 1.1, 'lambda_mst_sigma': 0.1, 'lambda_ifu': 1.1, 'lambda_ifu_sigma': 0.2,
-                        'kappa_ext': 0.01, 'kappa_ext_sigma': 0.03, 'alpha_lambda': 0.1, 'beta_lambda': 0.1}
+        kwargs = {
+            "lambda_mst": 1.1,
+            "lambda_mst_sigma": 0.1,
+            "lambda_ifu": 1.1,
+            "lambda_ifu_sigma": 0.2,
+            "kappa_ext": 0.01,
+            "kappa_ext_sigma": 0.03,
+            "alpha_lambda": 0.1,
+            "beta_lambda": 0.1,
+        }
         args = self._param.kwargs2args(kwargs)
         kwargs_new, i = self._param.args2kwargs(args, i=0)
         args_new = self._param.kwargs2args(kwargs_new)

--- a/test/test_Sampling/test_ParamManager/test_param_manager.py
+++ b/test/test_Sampling/test_ParamManager/test_param_manager.py
@@ -5,50 +5,119 @@ from hierarc.Sampling.ParamManager.param_manager import ParamManager
 
 
 class TestParamManager(object):
-
     def setup(self):
-        cosmology_list = ['FLCDM', "FwCDM", "w0waCDM", "oLCDM"]
-        kwargs_lower_cosmo = {'h0': 10, 'om': 0., 'ok': -0.5, 'w': -2, 'wa': -1, 'w0': -2, 'gamma_ppn': 0}
-        kwargs_lower_lens = {'lambda_mst': 0, 'lambda_mst_sigma': 0.1, 'kappa_ext': -0.2, 'kappa_ext_sigma': 0}
-        kwargs_lower_kin = {'a_ani': 0.1, 'a_ani_sigma': 0.1}
-        kwargs_lower_source = {'mu_sne': 0, 'sigma_sne': 0}
+        cosmology_list = ["FLCDM", "FwCDM", "w0waCDM", "oLCDM"]
+        kwargs_lower_cosmo = {
+            "h0": 10,
+            "om": 0.0,
+            "ok": -0.5,
+            "w": -2,
+            "wa": -1,
+            "w0": -2,
+            "gamma_ppn": 0,
+        }
+        kwargs_lower_lens = {
+            "lambda_mst": 0,
+            "lambda_mst_sigma": 0.1,
+            "kappa_ext": -0.2,
+            "kappa_ext_sigma": 0,
+        }
+        kwargs_lower_kin = {"a_ani": 0.1, "a_ani_sigma": 0.1}
+        kwargs_lower_source = {"mu_sne": 0, "sigma_sne": 0}
 
-        kwargs_upper_cosmo = {'h0': 200, 'om': 1, 'ok': 0.5, 'w': 0, 'wa': 1, 'w0': 1, 'gamma_ppn': 5}
-        kwargs_upper_lens = {'lambda_mst': 2, 'lambda_mst_sigma': 0.1, 'kappa_ext': 0.2, 'kappa_ext_sigma': 1}
-        kwargs_upper_kin = {'a_ani': 0.1, 'a_ani_sigma': 0.1}
-        kwargs_upper_source = {'mu_sne': 100, 'sigma_sne': 10}
+        kwargs_upper_cosmo = {
+            "h0": 200,
+            "om": 1,
+            "ok": 0.5,
+            "w": 0,
+            "wa": 1,
+            "w0": 1,
+            "gamma_ppn": 5,
+        }
+        kwargs_upper_lens = {
+            "lambda_mst": 2,
+            "lambda_mst_sigma": 0.1,
+            "kappa_ext": 0.2,
+            "kappa_ext_sigma": 1,
+        }
+        kwargs_upper_kin = {"a_ani": 0.1, "a_ani_sigma": 0.1}
+        kwargs_upper_source = {"mu_sne": 100, "sigma_sne": 10}
 
-        kwargs_fixed_cosmo = {'h0': 70, 'om': 0.3, 'ok': 0., 'w': -1, 'wa': -0, 'w0': -0, 'gamma_ppn': 1}
-        kwargs_fixed_lens = {'lambda_mst': 1, 'lambda_mst_sigma': 0.1, 'kappa_ext': 0, 'kappa_ext_sigma': 0}
-        kwargs_fixed_kin = {'a_ani': 0.1, 'a_ani_sigma': 0.1}
-        kwargs_fixed_source = {'mu_sne': 1, 'sigma_sne': 0.1}
+        kwargs_fixed_cosmo = {
+            "h0": 70,
+            "om": 0.3,
+            "ok": 0.0,
+            "w": -1,
+            "wa": -0,
+            "w0": -0,
+            "gamma_ppn": 1,
+        }
+        kwargs_fixed_lens = {
+            "lambda_mst": 1,
+            "lambda_mst_sigma": 0.1,
+            "kappa_ext": 0,
+            "kappa_ext_sigma": 0,
+        }
+        kwargs_fixed_kin = {"a_ani": 0.1, "a_ani_sigma": 0.1}
+        kwargs_fixed_source = {"mu_sne": 1, "sigma_sne": 0.1}
 
         param_list = []
         for cosmology in cosmology_list:
-            param_list.append(ParamManager(cosmology=cosmology, ppn_sampling=True, lambda_mst_sampling=True,
-                         lambda_mst_distribution='GAUSSIAN', anisotropy_distribution='GAUSSIAN',
-                         anisotropy_sampling=True, anisotropy_model='OM', kwargs_lower_cosmo=kwargs_lower_cosmo,
-                                           kappa_ext_sampling=True, kappa_ext_distribution='GAUSSIAN',
-                                           sne_apparent_m_sampling=True, sne_distribution='GAUSSIAN',
-                         kwargs_upper_cosmo=kwargs_upper_cosmo,
-                         kwargs_fixed_cosmo=kwargs_fixed_cosmo, kwargs_lower_lens=kwargs_lower_lens,
-                         kwargs_upper_lens=kwargs_upper_lens, kwargs_fixed_lens=kwargs_fixed_lens,
-                         kwargs_lower_kin=kwargs_lower_kin, kwargs_upper_kin=kwargs_upper_kin,
-                                           kwargs_fixed_kin=kwargs_fixed_kin,
-                                           kwargs_fixed_source=kwargs_fixed_source, kwargs_lower_source=kwargs_lower_source,
-                                           kwargs_upper_source=kwargs_upper_source))
+            param_list.append(
+                ParamManager(
+                    cosmology=cosmology,
+                    ppn_sampling=True,
+                    lambda_mst_sampling=True,
+                    lambda_mst_distribution="GAUSSIAN",
+                    anisotropy_distribution="GAUSSIAN",
+                    anisotropy_sampling=True,
+                    anisotropy_model="OM",
+                    kwargs_lower_cosmo=kwargs_lower_cosmo,
+                    kappa_ext_sampling=True,
+                    kappa_ext_distribution="GAUSSIAN",
+                    sne_apparent_m_sampling=True,
+                    sne_distribution="GAUSSIAN",
+                    kwargs_upper_cosmo=kwargs_upper_cosmo,
+                    kwargs_fixed_cosmo=kwargs_fixed_cosmo,
+                    kwargs_lower_lens=kwargs_lower_lens,
+                    kwargs_upper_lens=kwargs_upper_lens,
+                    kwargs_fixed_lens=kwargs_fixed_lens,
+                    kwargs_lower_kin=kwargs_lower_kin,
+                    kwargs_upper_kin=kwargs_upper_kin,
+                    kwargs_fixed_kin=kwargs_fixed_kin,
+                    kwargs_fixed_source=kwargs_fixed_source,
+                    kwargs_lower_source=kwargs_lower_source,
+                    kwargs_upper_source=kwargs_upper_source,
+                )
+            )
 
-            param_list.append(ParamManager(cosmology=cosmology, ppn_sampling=True, lambda_mst_sampling=True,
-                                           lambda_mst_distribution='GAUSSIAN', anisotropy_distribution='GAUSSIAN',
-                         anisotropy_sampling=True, anisotropy_model='OM', kappa_ext_sampling=True, kappa_ext_distribution='GAUSSIAN',
-                                           sne_apparent_m_sampling=True, sne_distribution='GAUSSIAN',
-                                           kwargs_lower_cosmo=kwargs_lower_cosmo,
-                         kwargs_upper_cosmo=kwargs_upper_cosmo,
-                         kwargs_fixed_cosmo=None, kwargs_lower_lens=kwargs_lower_lens,
-                         kwargs_upper_lens=kwargs_upper_lens, kwargs_fixed_lens=None,
-                         kwargs_lower_kin=kwargs_lower_kin, kwargs_upper_kin=kwargs_upper_kin,
-                                           kwargs_fixed_kin=None, kwargs_lower_source=kwargs_lower_source,
-                                           kwargs_upper_source=kwargs_upper_source, kwargs_fixed_source=None))
+            param_list.append(
+                ParamManager(
+                    cosmology=cosmology,
+                    ppn_sampling=True,
+                    lambda_mst_sampling=True,
+                    lambda_mst_distribution="GAUSSIAN",
+                    anisotropy_distribution="GAUSSIAN",
+                    anisotropy_sampling=True,
+                    anisotropy_model="OM",
+                    kappa_ext_sampling=True,
+                    kappa_ext_distribution="GAUSSIAN",
+                    sne_apparent_m_sampling=True,
+                    sne_distribution="GAUSSIAN",
+                    kwargs_lower_cosmo=kwargs_lower_cosmo,
+                    kwargs_upper_cosmo=kwargs_upper_cosmo,
+                    kwargs_fixed_cosmo=None,
+                    kwargs_lower_lens=kwargs_lower_lens,
+                    kwargs_upper_lens=kwargs_upper_lens,
+                    kwargs_fixed_lens=None,
+                    kwargs_lower_kin=kwargs_lower_kin,
+                    kwargs_upper_kin=kwargs_upper_kin,
+                    kwargs_fixed_kin=None,
+                    kwargs_lower_source=kwargs_lower_source,
+                    kwargs_upper_source=kwargs_upper_source,
+                    kwargs_fixed_source=None,
+                )
+            )
         self.param_list = param_list
 
     def test_num_param(self):
@@ -61,22 +130,54 @@ class TestParamManager(object):
             list = param.param_list(latex_style=False)
 
     def test_kwargs2args(self):
-        kwargs_cosmo = {'h0': 70, 'om': 0.3, 'ok': 0., 'w': -1, 'wa': -0, 'w0': -0, 'gamma_ppn': 1}
-        kwargs_lens = {'lambda_mst': 1, 'lambda_mst_sigma': 0, 'kappa_ext': 0, 'kappa_ext_sigma': 0}
-        kwargs_kin = {'a_ani': 1, 'a_ani_sigma': 0.3}
-        kwargs_source = {'mu_sne': 2, 'sigma_sne': 0.2}
+        kwargs_cosmo = {
+            "h0": 70,
+            "om": 0.3,
+            "ok": 0.0,
+            "w": -1,
+            "wa": -0,
+            "w0": -0,
+            "gamma_ppn": 1,
+        }
+        kwargs_lens = {
+            "lambda_mst": 1,
+            "lambda_mst_sigma": 0,
+            "kappa_ext": 0,
+            "kappa_ext_sigma": 0,
+        }
+        kwargs_kin = {"a_ani": 1, "a_ani_sigma": 0.3}
+        kwargs_source = {"mu_sne": 2, "sigma_sne": 0.2}
         for param in self.param_list:
-            args = param.kwargs2args(kwargs_cosmo=kwargs_cosmo, kwargs_lens=kwargs_lens, kwargs_kin=kwargs_kin,
-                                     kwargs_source=kwargs_source)
-            kwargs_cosmo_new, kwargs_lens_new, kwargs_kin_new, kwargs_source_new = param.args2kwargs(args)
-            args_new = param.kwargs2args(kwargs_cosmo_new, kwargs_lens_new, kwargs_kin_new, kwargs_source_new)
+            args = param.kwargs2args(
+                kwargs_cosmo=kwargs_cosmo,
+                kwargs_lens=kwargs_lens,
+                kwargs_kin=kwargs_kin,
+                kwargs_source=kwargs_source,
+            )
+            (
+                kwargs_cosmo_new,
+                kwargs_lens_new,
+                kwargs_kin_new,
+                kwargs_source_new,
+            ) = param.args2kwargs(args)
+            args_new = param.kwargs2args(
+                kwargs_cosmo_new, kwargs_lens_new, kwargs_kin_new, kwargs_source_new
+            )
             npt.assert_almost_equal(args_new, args)
 
     def test_cosmo(self):
-        kwargs_cosmo = {'h0': 70, 'om': 0.3, 'ok': 0., 'w': -1, 'wa': -0, 'w0': -0, 'gamma_ppn': 1}
+        kwargs_cosmo = {
+            "h0": 70,
+            "om": 0.3,
+            "ok": 0.0,
+            "w": -1,
+            "wa": -0,
+            "w0": -0,
+            "gamma_ppn": 1,
+        }
         for param in self.param_list:
             cosmo = param.cosmo(kwargs_cosmo)
-            assert hasattr(cosmo, 'H0')
+            assert hasattr(cosmo, "H0")
 
     def test_param_bounds(self):
         lower_limit, upper_limit = self.param_list[0].param_bounds
@@ -87,15 +188,26 @@ class TestParamManager(object):
 
 
 class TestRaise(unittest.TestCase):
-
     def test_raise(self):
-
         with self.assertRaises(ValueError):
-            ParamManager(cosmology='wrong', ppn_sampling=False, lambda_mst_sampling=False, lambda_mst_distribution='delta',
-                 anisotropy_sampling=False, anisotropy_model='OM', kwargs_lower_cosmo=None, kwargs_upper_cosmo=None,
-                 kwargs_fixed_cosmo={}, kwargs_lower_lens=None, kwargs_upper_lens=None, kwargs_fixed_lens={},
-                 kwargs_lower_kin=None, kwargs_upper_kin=None, kwargs_fixed_kin={})
+            ParamManager(
+                cosmology="wrong",
+                ppn_sampling=False,
+                lambda_mst_sampling=False,
+                lambda_mst_distribution="delta",
+                anisotropy_sampling=False,
+                anisotropy_model="OM",
+                kwargs_lower_cosmo=None,
+                kwargs_upper_cosmo=None,
+                kwargs_fixed_cosmo={},
+                kwargs_lower_lens=None,
+                kwargs_upper_lens=None,
+                kwargs_fixed_lens={},
+                kwargs_lower_kin=None,
+                kwargs_upper_kin=None,
+                kwargs_fixed_kin={},
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Sampling/test_ParamManager/test_source_param.py
+++ b/test/test_Sampling/test_ParamManager/test_source_param.py
@@ -5,12 +5,17 @@ import unittest
 
 
 class TestSourceParam(object):
-
     def setup(self):
-        self._param = SourceParam(sne_distribution='GAUSSIAN', sne_apparent_m_sampling=True, kwargs_fixed=None)
+        self._param = SourceParam(
+            sne_distribution="GAUSSIAN", sne_apparent_m_sampling=True, kwargs_fixed=None
+        )
 
-        kwargs_fixed = {'mu_sne': 1, 'sigma_sne': 0.1}
-        self._param_fixed = SourceParam(sne_distribution='GAUSSIAN', sne_apparent_m_sampling=True, kwargs_fixed=kwargs_fixed)
+        kwargs_fixed = {"mu_sne": 1, "sigma_sne": 0.1}
+        self._param_fixed = SourceParam(
+            sne_distribution="GAUSSIAN",
+            sne_apparent_m_sampling=True,
+            kwargs_fixed=kwargs_fixed,
+        )
 
     def test_param_list(self):
         param_list = self._param.param_list(latex_style=False)
@@ -24,7 +29,7 @@ class TestSourceParam(object):
         assert len(param_list) == 0
 
     def test_args2kwargs(self):
-        kwargs = {'mu_sne': 1, 'sigma_sne': 0.1}
+        kwargs = {"mu_sne": 1, "sigma_sne": 0.1}
         args = self._param.kwargs2args(kwargs)
         kwargs_new, i = self._param.args2kwargs(args, i=0)
         args_new = self._param.kwargs2args(kwargs_new)
@@ -37,12 +42,10 @@ class TestSourceParam(object):
 
 
 class TestRaise(unittest.TestCase):
-
     def test_raise(self):
-
         with self.assertRaises(ValueError):
-            param = SourceParam(sne_apparent_m_sampling=True, sne_distribution='BAD')
+            param = SourceParam(sne_apparent_m_sampling=True, sne_distribution="BAD")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Sampling/test_mcmc_sampling.py
+++ b/test/test_Sampling/test_mcmc_sampling.py
@@ -9,7 +9,6 @@ from astropy.cosmology import FlatLambdaCDM
 
 
 class TestMCMCSampling(object):
-
     def setup(self):
         np.random.seed(seed=41)
         self.z_L = 0.8
@@ -25,56 +24,96 @@ class TestMCMCSampling(object):
         self.sigma_Dd = 100
         self.sigma_Ddt = 100
         num_samples = 10000
-        self.D_dt_samples = np.random.normal(self.D_dt_true, self.sigma_Ddt, num_samples)
+        self.D_dt_samples = np.random.normal(
+            self.D_dt_true, self.sigma_Ddt, num_samples
+        )
         self.D_d_samples = np.random.normal(self.Dd_true, self.sigma_Dd, num_samples)
 
     def test_mcmc_emcee(self):
         n_walkers = 6
         n_run = 2
         n_burn = 2
-        kwargs_mean_start = {'kwargs_cosmo': {'h0': self.H0_true}}
-        kwargs_fixed = {'om': self.omega_m_true}
-        kwargs_sigma_start = {'kwargs_cosmo': {'h0': 5}}
-        kwargs_lower = {'h0': 10}
-        kwargs_upper = {'h0': 200}
-        kwargs_likelihood_list = [{'z_lens': self.z_L, 'z_source': self.z_S, 'likelihood_type': 'DdtDdKDE',
-                             'dd_samples': self.D_d_samples, 'ddt_samples': self.D_dt_samples,
-                             'kde_type': 'scipy_gaussian', 'bandwidth': 1}]
-        cosmology = 'FLCDM'
-        kwargs_bounds = {'kwargs_fixed_cosmo': kwargs_fixed, 'kwargs_lower_cosmo': kwargs_lower,
-                         'kwargs_upper_cosmo': kwargs_upper}
+        kwargs_mean_start = {"kwargs_cosmo": {"h0": self.H0_true}}
+        kwargs_fixed = {"om": self.omega_m_true}
+        kwargs_sigma_start = {"kwargs_cosmo": {"h0": 5}}
+        kwargs_lower = {"h0": 10}
+        kwargs_upper = {"h0": 200}
+        kwargs_likelihood_list = [
+            {
+                "z_lens": self.z_L,
+                "z_source": self.z_S,
+                "likelihood_type": "DdtDdKDE",
+                "dd_samples": self.D_d_samples,
+                "ddt_samples": self.D_dt_samples,
+                "kde_type": "scipy_gaussian",
+                "bandwidth": 1,
+            }
+        ]
+        cosmology = "FLCDM"
+        kwargs_bounds = {
+            "kwargs_fixed_cosmo": kwargs_fixed,
+            "kwargs_lower_cosmo": kwargs_lower,
+            "kwargs_upper_cosmo": kwargs_upper,
+        }
 
         path = os.getcwd()
-        backup_filename = 'test_emcee.h5'
+        backup_filename = "test_emcee.h5"
         try:
-            os.remove(os.path.join(path, backup_filename))  # just remove the backup file created above
+            os.remove(
+                os.path.join(path, backup_filename)
+            )  # just remove the backup file created above
         except:
             pass
 
         backend = emcee.backends.HDFBackend(backup_filename)
-        kwargs_emcee = {'backend': backend}
+        kwargs_emcee = {"backend": backend}
 
-        mcmc_sampler = MCMCSampler(kwargs_likelihood_list=kwargs_likelihood_list, cosmology=cosmology,
-                                   kwargs_bounds=kwargs_bounds, ppn_sampling=False,
-                 lambda_mst_sampling=False, lambda_mst_distribution='delta', anisotropy_sampling=False,
-                 anisotropy_model='OM', custom_prior=None, interpolate_cosmo=True, num_redshift_interp=100,
-                 cosmo_fixed=None)
-        samples, log_prob = mcmc_sampler.mcmc_emcee(n_walkers, n_burn, n_run, kwargs_mean_start, kwargs_sigma_start, **kwargs_emcee)
-        assert len(samples) == n_walkers*n_run
-        assert len(log_prob) == n_walkers*n_run
+        mcmc_sampler = MCMCSampler(
+            kwargs_likelihood_list=kwargs_likelihood_list,
+            cosmology=cosmology,
+            kwargs_bounds=kwargs_bounds,
+            ppn_sampling=False,
+            lambda_mst_sampling=False,
+            lambda_mst_distribution="delta",
+            anisotropy_sampling=False,
+            anisotropy_model="OM",
+            custom_prior=None,
+            interpolate_cosmo=True,
+            num_redshift_interp=100,
+            cosmo_fixed=None,
+        )
+        samples, log_prob = mcmc_sampler.mcmc_emcee(
+            n_walkers,
+            n_burn,
+            n_run,
+            kwargs_mean_start,
+            kwargs_sigma_start,
+            **kwargs_emcee
+        )
+        assert len(samples) == n_walkers * n_run
+        assert len(log_prob) == n_walkers * n_run
 
         n_burn_2 = 0
         n_run_2 = 2
-        samples, log_prob = mcmc_sampler.mcmc_emcee(n_walkers, n_burn_2, n_run_2, kwargs_mean_start, kwargs_sigma_start,
-                                                    continue_from_backend=True, **kwargs_emcee)
+        samples, log_prob = mcmc_sampler.mcmc_emcee(
+            n_walkers,
+            n_burn_2,
+            n_run_2,
+            kwargs_mean_start,
+            kwargs_sigma_start,
+            continue_from_backend=True,
+            **kwargs_emcee
+        )
         assert len(samples) == n_walkers * (n_run + n_run_2 + n_burn)
         assert len(log_prob) == n_walkers * (n_run + n_run_2 + n_burn)
 
         name_list = mcmc_sampler.param_names(latex_style=False)
         assert len(name_list) == 1
 
-        os.remove(os.path.join(path,backup_filename))  # just remove the backup file created above
+        os.remove(
+            os.path.join(path, backup_filename)
+        )  # just remove the backup file created above
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Util/test_distribution_util.py
+++ b/test/test_Util/test_distribution_util.py
@@ -7,43 +7,48 @@ from lenstronomy.Util import prob_density
 
 
 class TestProbDensity(object):
-
     def setup(self):
         np.random.seed(seed=42)
 
     def gauss(self, x, simga):
-        return np.exp(-(x/(simga))**2/2)
+        return np.exp(-((x / (simga)) ** 2) / 2)
 
     def test_approx_cdf_1d(self):
         bin_edges = np.linspace(start=-5, stop=5, num=501)
         x_array = (bin_edges[1:] + bin_edges[:-1]) / 2
-        sigma = 1.
+        sigma = 1.0
         pdf_array = self.gauss(x_array, simga=sigma)
         pdf_array /= np.sum(pdf_array)
 
-        cdf_array, cdf_func, cdf_inv_func = distribution_util.approx_cdf_1d(bin_edges, pdf_array)
+        cdf_array, cdf_func, cdf_inv_func = distribution_util.approx_cdf_1d(
+            bin_edges, pdf_array
+        )
         npt.assert_almost_equal(cdf_array[0], 0, decimal=7)
         npt.assert_almost_equal(cdf_array[-1], 1, decimal=8)
         npt.assert_almost_equal(cdf_func(0), 0.5, decimal=2)
-        npt.assert_almost_equal(cdf_inv_func(0.5), 0., decimal=2)
+        npt.assert_almost_equal(cdf_inv_func(0.5), 0.0, decimal=2)
 
     def test_compute_lower_upper_errors(self):
         x_array = np.linspace(-5, 5, 1000)
-        bin_edges = np.linspace(start=-5, stop=5, num=1000+1)
-        sigma = 1.
+        bin_edges = np.linspace(start=-5, stop=5, num=1000 + 1)
+        sigma = 1.0
         pdf_array = self.gauss(x_array, simga=sigma)
         approx = PDFSampling(bin_edges, pdf_array)
         np.random.seed(42)
         sample = approx.draw(n=20000)
-        mean, [[lower_sigma1, upper_sigma1], [lower_sigma2, upper_sigma2], [lower_sigma3, upper_sigma3]] = prob_density.compute_lower_upper_errors(sample, num_sigma=3)
+        mean, [
+            [lower_sigma1, upper_sigma1],
+            [lower_sigma2, upper_sigma2],
+            [lower_sigma3, upper_sigma3],
+        ] = prob_density.compute_lower_upper_errors(sample, num_sigma=3)
         npt.assert_almost_equal(mean, 0, decimal=2)
         npt.assert_almost_equal(lower_sigma1, sigma, decimal=2)
-        npt.assert_almost_equal(lower_sigma2, 2*sigma, decimal=1)
+        npt.assert_almost_equal(lower_sigma2, 2 * sigma, decimal=1)
         npt.assert_almost_equal(lower_sigma3, 3 * sigma, decimal=1)
 
         draw = approx.draw_one
         assert len(draw) == 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Util/test_ifu_util.py
+++ b/test/test_Util/test_ifu_util.py
@@ -7,7 +7,6 @@ from hierarc.Util import ifu_util
 
 
 class TestIFUUtil(object):
-
     def setup(self):
         pass
 
@@ -25,10 +24,18 @@ class TestIFUUtil(object):
 
         flux_map = np.ones((num, num))
 
-        disp_r, error_r = ifu_util.binned_total(dispersion_map, weight_map_disp, velocity_map, weight_map_v, flux_map, fiber_scale, r_bins)
+        disp_r, error_r = ifu_util.binned_total(
+            dispersion_map,
+            weight_map_disp,
+            velocity_map,
+            weight_map_v,
+            flux_map,
+            fiber_scale,
+            r_bins,
+        )
         assert len(disp_r) == len(r_bins) - 1
         npt.assert_almost_equal(disp_r, 1, decimal=6)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()

--- a/test/test_Util/test_likelihood_util.py
+++ b/test/test_Util/test_likelihood_util.py
@@ -7,7 +7,6 @@ from hierarc.Util import likelihood_util
 
 
 class TestLikelihoodUtil(object):
-
     def setup(self):
         pass
 
@@ -16,7 +15,9 @@ class TestLikelihoodUtil(object):
         draw = likelihood_util.get_truncated_normal(mean=0, sd=1, low=0, upp=10, size=1)
         npt.assert_almost_equal(draw, 0.48812700907868467, decimal=3)
 
-        draw = likelihood_util.get_truncated_normal(mean=0, sd=1, low=0, upp=10, size=10)
+        draw = likelihood_util.get_truncated_normal(
+            mean=0, sd=1, low=0, upp=10, size=10
+        )
         assert len(draw) == 10
 
     def test_log_likelihood_cov(self):
@@ -42,5 +43,5 @@ class TestLikelihoodUtil(object):
         npt.assert_almost_equal(logl, -1, decimal=1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
This PR:
- autoformats all the code and docstrings to comply with PEP8 and other helpful formatting standards.
- sets the maximum line length to 88.
- adds a yaml config file for automated formatting of all future commits using pre-commit.ci.