### PR TITLE
Marginalizing gamma_in distributions of individual systems

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,4 +13,6 @@ Contributors (alphabetical)
 * Aymeric Galan `aymgal <https://github.com/aymgal/>`_
 * Martin Millon `martin-millon <https://github.com/martin-millon>`_
 * Ji Won Park `jiwoncpark <https://github.com/jiwoncpark/>`_
+* Anowar Shajib `ajshajib <https://github.com/ajshajib>`_
+* William Sheu `williyamshoe <https://github.com/williyamshoe>`_
 * Chin-Yi Tan `chinyitan <https://github.com/chinyitan>`_

--- a/hierarc/LensPosterior/kin_constraints_composite.py
+++ b/hierarc/LensPosterior/kin_constraints_composite.py
@@ -81,7 +81,7 @@ class KinConstraintsComposite(KinConstraints):
         :param anisotropy_model: type of stellar anisotropy model. See details in
             MamonLokasAnisotropy() class of lenstronomy.GalKin.anisotropy
         :param gamma_in_prior_mean: prior mean for inner power-law slope of the NFW profile, if available
-        :param gamma_in_prior_std: 1-sigma error gamma_in
+        :param gamma_in_prior_std: prior standard deviation for `gamma_in`
         :param kwargs_lens_light: keyword argument list of lens light model (optional)
         :param kwargs_mge_light: keyword arguments that go into the MGE decomposition
             routine

--- a/hierarc/LensPosterior/kin_constraints_composite.py
+++ b/hierarc/LensPosterior/kin_constraints_composite.py
@@ -29,8 +29,8 @@ class KinConstraintsComposite(KinConstraints):
         kwargs_seeing,
         kwargs_numerics_galkin,
         anisotropy_model,
-        gamma_in_prior=None,
-        gamma_in_error=None,
+        gamma_in_prior_mean=None,
+        gamma_in_prior_std=None,
         sigma_v_error_independent=None,
         sigma_v_error_covariant=None,
         sigma_v_error_cov_matrix=None,
@@ -80,6 +80,8 @@ class KinConstraintsComposite(KinConstraints):
             line-of-sight velocity dispersion
         :param anisotropy_model: type of stellar anisotropy model. See details in
             MamonLokasAnisotropy() class of lenstronomy.GalKin.anisotropy
+        :param gamma_in_prior_mean: inner power-law slope of the NFW profile, if available
+        :param gamma_in_prior_std: 1-sigma error gamma_in
         :param kwargs_lens_light: keyword argument list of lens light model (optional)
         :param kwargs_mge_light: keyword arguments that go into the MGE decomposition
             routine
@@ -158,8 +160,8 @@ class KinConstraintsComposite(KinConstraints):
         self.log_m2l_array = log_m2l_array
         self._is_m2l_population_level = is_m2l_population_level
 
-        self._gamma_in_prior = gamma_in_prior
-        self._gamma_in_error = gamma_in_error
+        self._gamma_in_prior_mean = gamma_in_prior_mean
+        self._gamma_in_prior_std = gamma_in_prior_std
 
         if not is_m2l_population_level and not self._check_arrays(
             self._kappa_s_array, log_m2l_array
@@ -394,8 +396,8 @@ class KinConstraintsComposite(KinConstraints):
             "gamma_in_array": self.gamma_in_array,
             "log_m2l_array": self.log_m2l_array,
             "param_scaling_grid_list": ani_scaling_grid_list,
-            "gamma_in_prior": self._gamma_in_prior,
-            "gamma_in_error": self._gamma_in_error,
+            "gamma_in_prior_mean": self._gamma_in_prior_mean,
+            "gamma_in_prior_std": self._gamma_in_prior_std,
         }
 
         if not self._is_m2l_population_level:

--- a/hierarc/LensPosterior/kin_constraints_composite.py
+++ b/hierarc/LensPosterior/kin_constraints_composite.py
@@ -305,8 +305,6 @@ class KinConstraintsComposite(KinConstraints):
             kwargs_lens_stars,
         ]
 
-        print(kwargs_lens)
-
         j_kin = self.velocity_dispersion_map_dimension_less(
             kwargs_lens=kwargs_lens,
             kwargs_lens_light=kwargs_light,

--- a/hierarc/LensPosterior/kin_constraints_composite.py
+++ b/hierarc/LensPosterior/kin_constraints_composite.py
@@ -165,6 +165,11 @@ class KinConstraintsComposite(KinConstraints):
 
     @staticmethod
     def _check_arrays(array0, array1):
+        """Checks if two arrays are valid sample distributions for pairs of parameters
+
+        :param array0, array1: arrays representing samples from respective distributions
+        :return: bool, True if arrays are the same length and > 0; False otherwise
+        """
         if array0 is None or array1 is None:
             return False
         return len(array0) == len(array1) and len(array0) > 0

--- a/hierarc/LensPosterior/kin_constraints_composite.py
+++ b/hierarc/LensPosterior/kin_constraints_composite.py
@@ -165,7 +165,7 @@ class KinConstraintsComposite(KinConstraints):
 
     @staticmethod
     def _check_arrays(array0, array1):
-        """Checks if two arrays are valid sample distributions for pairs of parameters
+        """Checks if two arrays are valid sample distributions for pairs of parameters.
 
         :param array0, array1: arrays representing samples from respective distributions
         :return: bool, True if arrays are the same length and > 0; False otherwise

--- a/hierarc/LensPosterior/kin_constraints_composite.py
+++ b/hierarc/LensPosterior/kin_constraints_composite.py
@@ -80,7 +80,7 @@ class KinConstraintsComposite(KinConstraints):
             line-of-sight velocity dispersion
         :param anisotropy_model: type of stellar anisotropy model. See details in
             MamonLokasAnisotropy() class of lenstronomy.GalKin.anisotropy
-        :param gamma_in_prior_mean: inner power-law slope of the NFW profile, if available
+        :param gamma_in_prior_mean: prior mean for inner power-law slope of the NFW profile, if available
         :param gamma_in_prior_std: 1-sigma error gamma_in
         :param kwargs_lens_light: keyword argument list of lens light model (optional)
         :param kwargs_mge_light: keyword arguments that go into the MGE decomposition

--- a/hierarc/LensPosterior/kin_constraints_composite.py
+++ b/hierarc/LensPosterior/kin_constraints_composite.py
@@ -397,7 +397,7 @@ class KinConstraintsComposite(KinConstraints):
             "log_m2l_array": self.log_m2l_array,
             "param_scaling_grid_list": ani_scaling_grid_list,
             "gamma_in_prior": self._gamma_in_prior,
-            "gamma_in_error": self.gamma_in_error,
+            "gamma_in_error": self._gamma_in_error,
         }
 
         if not self._is_m2l_population_level:

--- a/hierarc/LensPosterior/kin_constraints_composite.py
+++ b/hierarc/LensPosterior/kin_constraints_composite.py
@@ -81,7 +81,7 @@ class KinConstraintsComposite(KinConstraints):
         :param anisotropy_model: type of stellar anisotropy model. See details in
             MamonLokasAnisotropy() class of lenstronomy.GalKin.anisotropy
         :param gamma_in_prior_mean: prior mean for inner power-law slope of the NFW profile, if available
-        :param gamma_in_prior_std: prior standard deviation for `gamma_in`
+        :param gamma_in_prior_std: standard deviation of the Gaussian prior for `gamma_in`
         :param kwargs_lens_light: keyword argument list of lens light model (optional)
         :param kwargs_mge_light: keyword arguments that go into the MGE decomposition
             routine

--- a/hierarc/Likelihood/cosmo_likelihood.py
+++ b/hierarc/Likelihood/cosmo_likelihood.py
@@ -81,7 +81,7 @@ class CosmoLikelihood(object):
         :param anisotropy_distribution: string, distribution of the anisotropy parameters
         :param gamma_in_sampling: bool, if True samples gNFW inner slope parameter
         :param gamma_in_distribution: string, distribution function of the gamma_in parameter
-        :param log_m2l_sampling: bool, if True samples a global mass-to-light ratio parameter
+        :param log_m2l_sampling: bool, if True samples a global mass-to-light ratio parameter in logarithmic scale
         :param log_m2l_distribution: string, distribution function of the log_m2l parameter
         :param sigma_v_systematics: bool, if True samples paramaters relative to systematics in the velocity dispersion
          measurement

--- a/hierarc/Likelihood/cosmo_likelihood.py
+++ b/hierarc/Likelihood/cosmo_likelihood.py
@@ -25,14 +25,14 @@ class CosmoLikelihood(object):
         anisotropy_sampling=False,
         gamma_in_sampling=False,
         gamma_in_distribution="NONE",
-        m2l_sampling=False,
-        m2l_distribution="NONE",
+        log_m2l_sampling=False,
+        log_m2l_distribution="NONE",
         kappa_ext_sampling=False,
         kappa_ext_distribution="NONE",
         alpha_lambda_sampling=False,
         beta_lambda_sampling=False,
         alpha_gamma_in_sampling=False,
-        alpha_m2l_sampling=False,
+        alpha_log_m2l_sampling=False,
         lambda_ifu_sampling=False,
         lambda_ifu_distribution="NONE",
         sigma_v_systematics=False,
@@ -81,8 +81,8 @@ class CosmoLikelihood(object):
         :param anisotropy_distribution: string, distribution of the anisotropy parameters
         :param gamma_in_sampling: bool, if True samples gNFW inner slope parameter
         :param gamma_in_distribution: string, distribution function of the gamma_in parameter
-        :param m2l_sampling: bool, if True samples a global mass-to-light ratio parameter
-        :param m2l_distribution: string, distribution function of the m2l parameter
+        :param log_m2l_sampling: bool, if True samples a global mass-to-light ratio parameter
+        :param log_m2l_distribution: string, distribution function of the log_m2l parameter
         :param sigma_v_systematics: bool, if True samples paramaters relative to systematics in the velocity dispersion
          measurement
         :param sne_apparent_m_sampling: boolean, if True, samples/queries SNe unlensed magnitude distribution
@@ -119,10 +119,10 @@ class CosmoLikelihood(object):
             beta_lambda_sampling=beta_lambda_sampling,
             gamma_in_sampling=gamma_in_sampling,
             gamma_in_distribution=gamma_in_distribution,
-            m2l_sampling=m2l_sampling,
-            m2l_distribution=m2l_distribution,
+            log_m2l_sampling=log_m2l_sampling,
+            log_m2l_distribution=log_m2l_distribution,
             alpha_gamma_in_sampling=alpha_gamma_in_sampling,
-            alpha_m2l_sampling=alpha_m2l_sampling,
+            alpha_log_m2l_sampling=alpha_log_m2l_sampling,
             sne_apparent_m_sampling=sne_apparent_m_sampling,
             sne_distribution=sne_distribution,
             z_apparent_m_anchor=z_apparent_m_anchor,

--- a/hierarc/Likelihood/hierarchy_likelihood.py
+++ b/hierarc/Likelihood/hierarchy_likelihood.py
@@ -66,7 +66,7 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, ParameterScalin
         :param normalized: bool, if True, returns the normalized likelihood, if False, separates the constant prefactor
          (in case of a Gaussian 1/(sigma sqrt(2 pi)) ) to compute the reduced chi2 statistics
         :param kwargs_lens_properties: keyword arguments of the lens properties
-        :param gamma_in_prior_mean: inner power-law slope of the NFW profile, if available
+        :param gamma_in_prior_mean: prior mean for inner power-law slope of the NFW profile, if available
         :param gamma_in_prior_std: 1-sigma error gamma_in
         :param kwargs_likelihood: keyword arguments specifying the likelihood function,
         see individual classes for their use

--- a/hierarc/Likelihood/hierarchy_likelihood.py
+++ b/hierarc/Likelihood/hierarchy_likelihood.py
@@ -67,7 +67,7 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, ParameterScalin
          (in case of a Gaussian 1/(sigma sqrt(2 pi)) ) to compute the reduced chi2 statistics
         :param kwargs_lens_properties: keyword arguments of the lens properties
         :param gamma_in_prior_mean: prior mean for inner power-law slope of the NFW profile, if available
-        :param gamma_in_prior_std: 1-sigma error gamma_in
+        :param gamma_in_prior_std: standard deviation of the Gaussian prior for gamma_in
         :param kwargs_likelihood: keyword arguments specifying the likelihood function,
         see individual classes for their use
         """

--- a/hierarc/Likelihood/hierarchy_likelihood.py
+++ b/hierarc/Likelihood/hierarchy_likelihood.py
@@ -283,7 +283,10 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, ParameterScalin
             mu_intrinsic=mag_source_,
         )
 
-        if self._gamma_in_prior_mean is not None and self._gamma_in_prior_std is not None:
+        if (
+            self._gamma_in_prior_mean is not None
+            and self._gamma_in_prior_std is not None
+        ):
             if self._gamma_in_array is not None and self._log_m2l_array is not None:
                 lnlikelihood -= (
                     self._gamma_in_prior_mean - scaling_param_array[-2]

--- a/hierarc/Likelihood/hierarchy_likelihood.py
+++ b/hierarc/Likelihood/hierarchy_likelihood.py
@@ -283,9 +283,13 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, ParameterScalin
 
         if self._gamma_in_prior is not None and self._gamma_in_error is not None:
             if self._gamma_in_array is not None and self._log_m2l_array is not None:
-                lnlikelihood -= (self._gamma_in_prior - scaling_param_array[-2])**2 / (2 * self._gamma_in_error**2)
+                lnlikelihood -= (
+                    self._gamma_in_prior - scaling_param_array[-2]
+                ) ** 2 / (2 * self._gamma_in_error**2)
             elif self._gamma_in_array is not None and self._log_m2l_array is None:
-                lnlikelihood -= (self._gamma_in_prior - scaling_param_array[-1])**2 / (2 * self._gamma_in_error**2)
+                lnlikelihood -= (
+                    self._gamma_in_prior - scaling_param_array[-1]
+                ) ** 2 / (2 * self._gamma_in_error**2)
 
         return np.nan_to_num(lnlikelihood)
 

--- a/hierarc/Likelihood/hierarchy_likelihood.py
+++ b/hierarc/Likelihood/hierarchy_likelihood.py
@@ -32,8 +32,8 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, ParameterScalin
         lambda_scaling_property_beta=0,
         normalized=True,
         kwargs_lens_properties=None,
-        gamma_in_prior=None,
-        gamma_in_error=None,
+        gamma_in_prior_mean=None,
+        gamma_in_prior_std=None,
         **kwargs_likelihood
     ):
         """
@@ -66,6 +66,8 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, ParameterScalin
         :param normalized: bool, if True, returns the normalized likelihood, if False, separates the constant prefactor
          (in case of a Gaussian 1/(sigma sqrt(2 pi)) ) to compute the reduced chi2 statistics
         :param kwargs_lens_properties: keyword arguments of the lens properties
+        :param gamma_in_prior_mean: inner power-law slope of the NFW profile, if available
+        :param gamma_in_prior_std: 1-sigma error gamma_in
         :param kwargs_likelihood: keyword arguments specifying the likelihood function,
         see individual classes for their use
         """
@@ -134,8 +136,8 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, ParameterScalin
         self._gamma_in_array = gamma_in_array
         self._log_m2l_array = log_m2l_array
 
-        self._gamma_in_prior = gamma_in_prior
-        self._gamma_in_error = gamma_in_error
+        self._gamma_in_prior_mean = gamma_in_prior_mean
+        self._gamma_in_prior_std = gamma_in_prior_std
 
     def lens_log_likelihood(
         self, cosmo, kwargs_lens=None, kwargs_kin=None, kwargs_source=None
@@ -281,15 +283,15 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, ParameterScalin
             mu_intrinsic=mag_source_,
         )
 
-        if self._gamma_in_prior is not None and self._gamma_in_error is not None:
+        if self._gamma_in_prior_mean is not None and self._gamma_in_prior_std is not None:
             if self._gamma_in_array is not None and self._log_m2l_array is not None:
                 lnlikelihood -= (
-                    self._gamma_in_prior - scaling_param_array[-2]
-                ) ** 2 / (2 * self._gamma_in_error**2)
+                    self._gamma_in_prior_mean - scaling_param_array[-2]
+                ) ** 2 / (2 * self._gamma_in_prior_std**2)
             elif self._gamma_in_array is not None and self._log_m2l_array is None:
                 lnlikelihood -= (
-                    self._gamma_in_prior - scaling_param_array[-1]
-                ) ** 2 / (2 * self._gamma_in_error**2)
+                    self._gamma_in_prior_mean - scaling_param_array[-1]
+                ) ** 2 / (2 * self._gamma_in_prior_std**2)
 
         return np.nan_to_num(lnlikelihood)
 

--- a/hierarc/Sampling/ParamManager/lens_param.py
+++ b/hierarc/Sampling/ParamManager/lens_param.py
@@ -12,14 +12,14 @@ class LensParam(object):
         lambda_ifu_distribution="NONE",
         gamma_in_sampling=False,
         gamma_in_distribution="NONE",
-        m2l_sampling=False,
-        m2l_distribution="NONE",
+        log_m2l_sampling=False,
+        log_m2l_distribution="NONE",
         kappa_ext_sampling=False,
         kappa_ext_distribution="NONE",
         alpha_lambda_sampling=False,
         beta_lambda_sampling=False,
         alpha_gamma_in_sampling=False,
-        alpha_m2l_sampling=False,
+        alpha_log_m2l_sampling=False,
         kwargs_fixed=None,
         log_scatter=False,
     ):
@@ -33,9 +33,9 @@ class LensParam(object):
         :param gamma_in_sampling: bool, if True samples the inner slope of the GNFW profile
         :param gamma_in_distribution: string, distribution function of the inner
             slope of the GNFW profile
-        :param m2l_sampling: bool, if True samples the mass to light ratio of
+        :param log_m2l_sampling: bool, if True samples the mass to light ratio of
             the stars
-        :param m2l_distribution: string, distribution function of the mass to
+        :param log_m2l_distribution: string, distribution function of the mass to
             light ratio of the lens
         :param kappa_ext_sampling: bool, if True samples a global external convergence
             parameter
@@ -46,7 +46,7 @@ class LensParam(object):
         :param beta_lambda_sampling: bool, if True samples a parameter beta_lambda, which scales lambda_mst linearly
             according to a predefined quantity of the lens
         :param alpha_gamma_in_sampling: bool, if True samples a parameter alpha_gamma_in, which scales gamma_in linearly
-        :param alpha_m2l_sampling: bool, if True samples a parameter alpha_m2l, which scales m2l linearly
+        :param alpha_log_m2l_sampling: bool, if True samples a parameter alpha_log_m2l, which scales log_m2l linearly
         :param log_scatter: boolean, if True, samples the Gaussian scatter amplitude in log space (and thus flat prior in log)
         :param kwargs_fixed: keyword arguments that are held fixed through the sampling
         """
@@ -56,14 +56,14 @@ class LensParam(object):
         self._lambda_ifu_distribution = lambda_ifu_distribution
         self._gamma_in_sampling = gamma_in_sampling
         self._gamma_in_distribution = gamma_in_distribution
-        self._m2l_sampling = m2l_sampling
-        self._m2l_distribution = m2l_distribution
+        self._log_m2l_sampling = log_m2l_sampling
+        self._log_m2l_distribution = log_m2l_distribution
         self._kappa_ext_sampling = kappa_ext_sampling
         self._kappa_ext_distribution = kappa_ext_distribution
         self._alpha_lambda_sampling = alpha_lambda_sampling
         self._beta_lambda_sampling = beta_lambda_sampling
         self._alpha_gamma_in_sampling = alpha_gamma_in_sampling
-        self._alpha_m2l_sampling = alpha_m2l_sampling
+        self._alpha_log_m2l_sampling = alpha_log_m2l_sampling
 
         self._log_scatter = log_scatter
         if kwargs_fixed is None:
@@ -122,21 +122,21 @@ class LensParam(object):
                             list.append(r"$\sigma(\gamma_{\rm in})$")
                     else:
                         list.append("gamma_in_sigma")
-        if self._m2l_sampling is True:
-            if "m2l" not in self._kwargs_fixed:
+        if self._log_m2l_sampling is True:
+            if "log_m2l" not in self._kwargs_fixed:
                 if latex_style is True:
                     list.append(r"$\Upsilon_{\rm stars}$")
                 else:
-                    list.append("m2l")
-            if self._m2l_distribution == "GAUSSIAN":
-                if "m2l_sigma" not in self._kwargs_fixed:
+                    list.append("log_m2l")
+            if self._log_m2l_distribution == "GAUSSIAN":
+                if "log_m2l_sigma" not in self._kwargs_fixed:
                     if latex_style is True:
                         if self._log_scatter is True:
                             list.append(r"$\log_{10}\sigma(\Upsilon_{\rm stars})$")
                         else:
                             list.append(r"$\sigma(\Upsilon_{\rm stars})$")
                     else:
-                        list.append("m2l_sigma")
+                        list.append("log_m2l_sigma")
         if self._kappa_ext_sampling is True:
             if "kappa_ext" not in self._kwargs_fixed:
                 if latex_style is True:
@@ -167,12 +167,12 @@ class LensParam(object):
                     list.append(r"$\alpha_{\gamma_{\rm in}}$")
                 else:
                     list.append("alpha_gamma_in")
-        if self._alpha_m2l_sampling is True:
-            if "alpha_m2l" not in self._kwargs_fixed:
+        if self._alpha_log_m2l_sampling is True:
+            if "alpha_log_m2l" not in self._kwargs_fixed:
                 if latex_style is True:
                     list.append(r"$\alpha_{\Upsilon_{\rm stars}}$")
                 else:
-                    list.append("alpha_m2l")
+                    list.append("alpha_log_m2l")
         return list
 
     def args2kwargs(self, args, i=0):
@@ -227,20 +227,20 @@ class LensParam(object):
                     else:
                         kwargs["gamma_in_sigma"] = args[i]
                     i += 1
-        if self._m2l_sampling is True:
-            if "m2l" in self._kwargs_fixed:
-                kwargs["m2l"] = self._kwargs_fixed["m2l"]
+        if self._log_m2l_sampling is True:
+            if "log_m2l" in self._kwargs_fixed:
+                kwargs["log_m2l"] = self._kwargs_fixed["log_m2l"]
             else:
-                kwargs["m2l"] = args[i]
+                kwargs["log_m2l"] = args[i]
                 i += 1
-            if self._m2l_distribution == "GAUSSIAN":
-                if "m2l_sigma" in self._kwargs_fixed:
-                    kwargs["m2l_sigma"] = self._kwargs_fixed["m2l_sigma"]
+            if self._log_m2l_distribution == "GAUSSIAN":
+                if "log_m2l_sigma" in self._kwargs_fixed:
+                    kwargs["log_m2l_sigma"] = self._kwargs_fixed["log_m2l_sigma"]
                 else:
                     if self._log_scatter is True:
-                        kwargs["m2l_sigma"] = 10 ** (args[i])
+                        kwargs["log_m2l_sigma"] = 10 ** (args[i])
                     else:
-                        kwargs["m2l_sigma"] = args[i]
+                        kwargs["log_m2l_sigma"] = args[i]
                     i += 1
         if self._kappa_ext_sampling is True:
             if "kappa_ext" in self._kwargs_fixed:
@@ -272,11 +272,11 @@ class LensParam(object):
             else:
                 kwargs["alpha_gamma_in"] = args[i]
                 i += 1
-        if self._alpha_m2l_sampling is True:
-            if "alpha_m2l" in self._kwargs_fixed:
-                kwargs["alpha_m2l"] = self._kwargs_fixed["alpha_m2l"]
+        if self._alpha_log_m2l_sampling is True:
+            if "alpha_log_m2l" in self._kwargs_fixed:
+                kwargs["alpha_log_m2l"] = self._kwargs_fixed["alpha_log_m2l"]
             else:
-                kwargs["alpha_m2l"] = args[i]
+                kwargs["alpha_log_m2l"] = args[i]
                 i += 1
 
         return kwargs, i
@@ -315,15 +315,15 @@ class LensParam(object):
                         args.append(np.log10(kwargs["gamma_in_sigma"]))
                     else:
                         args.append(kwargs["gamma_in_sigma"])
-        if self._m2l_sampling is True:
-            if "m2l" not in self._kwargs_fixed:
-                args.append(kwargs["m2l"])
-            if self._m2l_distribution == "GAUSSIAN":
-                if "m2l_sigma" not in self._kwargs_fixed:
+        if self._log_m2l_sampling is True:
+            if "log_m2l" not in self._kwargs_fixed:
+                args.append(kwargs["log_m2l"])
+            if self._log_m2l_distribution == "GAUSSIAN":
+                if "log_m2l_sigma" not in self._kwargs_fixed:
                     if self._log_scatter is True:
-                        args.append(np.log10(kwargs["m2l_sigma"]))
+                        args.append(np.log10(kwargs["log_m2l_sigma"]))
                     else:
-                        args.append(kwargs["m2l_sigma"])
+                        args.append(kwargs["log_m2l_sigma"])
         if self._kappa_ext_sampling is True:
             if "kappa_ext" not in self._kwargs_fixed:
                 args.append(kwargs["kappa_ext"])
@@ -339,7 +339,7 @@ class LensParam(object):
         if self._alpha_gamma_in_sampling is True:
             if "alpha_gamma_in" not in self._kwargs_fixed:
                 args.append(kwargs["alpha_gamma_in"])
-        if self._alpha_m2l_sampling is True:
-            if "alpha_m2l" not in self._kwargs_fixed:
-                args.append(kwargs["alpha_m2l"])
+        if self._alpha_log_m2l_sampling is True:
+            if "alpha_log_m2l" not in self._kwargs_fixed:
+                args.append(kwargs["alpha_log_m2l"])
         return args

--- a/hierarc/Sampling/ParamManager/lens_param.py
+++ b/hierarc/Sampling/ParamManager/lens_param.py
@@ -35,7 +35,7 @@ class LensParam(object):
             slope of the GNFW profile
         :param log_m2l_sampling: bool, if True samples the mass to light ratio of
             the stars
-        :param log_m2l_distribution: string, distribution function of the mass to
+        :param log_m2l_distribution: string, distribution function of the logarithm of mass to
             light ratio of the lens
         :param kappa_ext_sampling: bool, if True samples a global external convergence
             parameter

--- a/hierarc/Sampling/ParamManager/lens_param.py
+++ b/hierarc/Sampling/ParamManager/lens_param.py
@@ -34,7 +34,7 @@ class LensParam(object):
         :param gamma_in_distribution: string, distribution function of the inner
             slope of the GNFW profile
         :param log_m2l_sampling: bool, if True samples the mass to light ratio of
-            the stars
+            the stars in logarithmic scale
         :param log_m2l_distribution: string, distribution function of the logarithm of mass to
             light ratio of the lens
         :param kappa_ext_sampling: bool, if True samples a global external convergence

--- a/hierarc/Sampling/ParamManager/param_manager.py
+++ b/hierarc/Sampling/ParamManager/param_manager.py
@@ -64,7 +64,7 @@ class ParamManager(object):
         :param anisotropy_distribution: string, indicating the distribution function of the anisotropy model
         :param gamma_in_sampling: bool, if True samples gNFW inner slope parameter
         :param gamma_in_distribution: string, distribution function of the gamma_in parameter
-        :param log_m2l_sampling: bool, if True samples the mass-to-light ratio of the stars
+        :param log_m2l_sampling: bool, if True samples the mass-to-light ratio of the stars in logarithmic scale
         :param log_m2l_distribution: string, distribution function of the log_m2l parameter
         :param alpha_gamma_in_sampling: bool, if True samples a parameter alpha_gamma_in, which scales gamma_in linearly
             according to a predefined quantity of the lens

--- a/hierarc/Sampling/ParamManager/param_manager.py
+++ b/hierarc/Sampling/ParamManager/param_manager.py
@@ -18,8 +18,8 @@ class ParamManager(object):
         anisotropy_distribution="NONE",
         gamma_in_sampling=False,
         gamma_in_distribution="NONE",
-        m2l_sampling=False,
-        m2l_distribution="NONE",
+        log_m2l_sampling=False,
+        log_m2l_distribution="NONE",
         kappa_ext_sampling=False,
         kappa_ext_distribution="NONE",
         lambda_ifu_sampling=False,
@@ -27,7 +27,7 @@ class ParamManager(object):
         alpha_lambda_sampling=False,
         beta_lambda_sampling=False,
         alpha_gamma_in_sampling=False,
-        alpha_m2l_sampling=False,
+        alpha_log_m2l_sampling=False,
         sigma_v_systematics=False,
         sne_apparent_m_sampling=False,
         sne_distribution="GAUSSIAN",
@@ -64,11 +64,11 @@ class ParamManager(object):
         :param anisotropy_distribution: string, indicating the distribution function of the anisotropy model
         :param gamma_in_sampling: bool, if True samples gNFW inner slope parameter
         :param gamma_in_distribution: string, distribution function of the gamma_in parameter
-        :param m2l_sampling: bool, if True samples the mass-to-light ratio of the stars
-        :param m2l_distribution: string, distribution function of the m2l parameter
+        :param log_m2l_sampling: bool, if True samples the mass-to-light ratio of the stars
+        :param log_m2l_distribution: string, distribution function of the log_m2l parameter
         :param alpha_gamma_in_sampling: bool, if True samples a parameter alpha_gamma_in, which scales gamma_in linearly
             according to a predefined quantity of the lens
-        :param alpha_m2l_sampling: bool, if True samples a parameter alpha_m2l, which scales m2l linearly
+        :param alpha_log_m2l_sampling: bool, if True samples a parameter alpha_log_m2l, which scales log_m2l linearly
             according to a predefined quantity of the lens
         :param sne_apparent_m_sampling: boolean, if True, samples/queries SNe unlensed magnitude distribution
          (not intrinsic magnitudes but apparent!)
@@ -99,14 +99,14 @@ class ParamManager(object):
             lambda_ifu_distribution=lambda_ifu_distribution,
             gamma_in_sampling=gamma_in_sampling,
             gamma_in_distribution=gamma_in_distribution,
-            m2l_sampling=m2l_sampling,
-            m2l_distribution=m2l_distribution,
+            log_m2l_sampling=log_m2l_sampling,
+            log_m2l_distribution=log_m2l_distribution,
             kappa_ext_sampling=kappa_ext_sampling,
             kappa_ext_distribution=kappa_ext_distribution,
             alpha_lambda_sampling=alpha_lambda_sampling,
             beta_lambda_sampling=beta_lambda_sampling,
             alpha_gamma_in_sampling=alpha_gamma_in_sampling,
-            alpha_m2l_sampling=alpha_m2l_sampling,
+            alpha_log_m2l_sampling=alpha_log_m2l_sampling,
             log_scatter=log_scatter,
             kwargs_fixed=kwargs_fixed_lens,
         )

--- a/test/test_LensPosterior/test_kin_constraints_composite.py
+++ b/test/test_LensPosterior/test_kin_constraints_composite.py
@@ -249,8 +249,8 @@ class TestKinConstraintsComposite(object):
             anisotropy_model=anisotropy_model,
             kwargs_lens_light=kwargs_lens_light,
             lens_light_model_list=lens_light_model_list,
-            gamma_in_prior=2,
-            gamma_in_error=0.5,
+            gamma_in_prior_mean=2,
+            gamma_in_prior_std=0.5,
             **kwargs_kin_api_settings
         )
 
@@ -351,8 +351,8 @@ class TestKinConstraintsCompositeM2l(object):
             kwargs_lens_light=kwargs_lens_light,
             lens_light_model_list=lens_light_model_list,
             is_m2l_population_level=False,
-            gamma_in_prior=2,
-            gamma_in_error=0.5,
+            gamma_in_prior_mean=2,
+            gamma_in_prior_std=0.5,
             **kwargs_kin_api_settings
         )
 

--- a/test/test_LensPosterior/test_kin_constraints_composite.py
+++ b/test/test_LensPosterior/test_kin_constraints_composite.py
@@ -914,7 +914,7 @@ class TestRaise(unittest.TestCase):
                 **kwargs_kin_api_settings
             )
             kin_constraints._anisotropy_model = "BAD"
-            kin_constraints._anisotropy_scaling_relative(j_ani_0=1)
+            kin_constraints._anisotropy_scaling_relative_m2l(j_ani_0=1)
 
 
 if __name__ == "__main__":

--- a/test/test_LensPosterior/test_kin_constraints_composite.py
+++ b/test/test_LensPosterior/test_kin_constraints_composite.py
@@ -249,6 +249,8 @@ class TestKinConstraintsComposite(object):
             anisotropy_model=anisotropy_model,
             kwargs_lens_light=kwargs_lens_light,
             lens_light_model_list=lens_light_model_list,
+            gamma_in_prior=2,
+            gamma_in_error=0.5,
             **kwargs_kin_api_settings
         )
 
@@ -349,6 +351,8 @@ class TestKinConstraintsCompositeM2l(object):
             kwargs_lens_light=kwargs_lens_light,
             lens_light_model_list=lens_light_model_list,
             is_m2l_population_level=False,
+            gamma_in_prior=2,
+            gamma_in_error=0.5,
             **kwargs_kin_api_settings
         )
 

--- a/test/test_Sampling/test_ParamManager/test_lens_param.py
+++ b/test/test_Sampling/test_ParamManager/test_lens_param.py
@@ -98,10 +98,10 @@ class TestLensParamGammaInnerM2l(object):
         self._param = LensParam(
             gamma_in_sampling=True,
             gamma_in_distribution="GAUSSIAN",
-            m2l_sampling=True,
-            m2l_distribution="GAUSSIAN",
+            log_m2l_sampling=True,
+            log_m2l_distribution="GAUSSIAN",
             alpha_gamma_in_sampling=True,
-            alpha_m2l_sampling=True,
+            alpha_log_m2l_sampling=True,
             kwargs_fixed={},
             log_scatter=False,
         )
@@ -109,28 +109,28 @@ class TestLensParamGammaInnerM2l(object):
         kwargs_fixed = {
             "gamma_in": 1,
             "gamma_in_sigma": 0.1,
-            "m2l": 5,
-            "m2l_sigma": 1,
+            "log_m2l": 5,
+            "log_m2l_sigma": 1,
             "alpha_gamma_in": 0.1,
-            "alpha_m2l": -0.5,
+            "alpha_log_m2l": -0.5,
         }
         self._param_fixed = LensParam(
             gamma_in_sampling=True,
             gamma_in_distribution="GAUSSIAN",
-            m2l_sampling=True,
-            m2l_distribution="GAUSSIAN",
+            log_m2l_sampling=True,
+            log_m2l_distribution="GAUSSIAN",
             alpha_gamma_in_sampling=True,
-            alpha_m2l_sampling=True,
+            alpha_log_m2l_sampling=True,
             kwargs_fixed=kwargs_fixed,
             log_scatter=False,
         )
         self._param_log_scatter = LensParam(
             gamma_in_sampling=True,
             gamma_in_distribution="GAUSSIAN",
-            m2l_sampling=True,
-            m2l_distribution="GAUSSIAN",
+            log_m2l_sampling=True,
+            log_m2l_distribution="GAUSSIAN",
             alpha_gamma_in_sampling=True,
-            alpha_m2l_sampling=True,
+            alpha_log_m2l_sampling=True,
             kwargs_fixed={},
             log_scatter=True,
         )
@@ -155,10 +155,10 @@ class TestLensParamGammaInnerM2l(object):
         kwargs = {
             "gamma_in": 1,
             "gamma_in_sigma": 0.1,
-            "m2l": 5,
-            "m2l_sigma": 1,
+            "log_m2l": 5,
+            "log_m2l_sigma": 1,
             "alpha_gamma_in": 0.1,
-            "alpha_m2l": -0.5,
+            "alpha_log_m2l": -0.5,
         }
         args = self._param.kwargs2args(kwargs)
         kwargs_new, i = self._param.args2kwargs(args, i=0)


### PR DESCRIPTION
This PR: 
- adds a feature to marginalize `gamma_in` distributions of individual systems at a population level.  
- adds @ajshajib and @williyamshoe as contributors in the AUTHORS.rst.