### PR TITLE
Voronoi preprocessing

### DIFF
--- a/hierarc/LensPosterior/ddt_kin_constraints.py
+++ b/hierarc/LensPosterior/ddt_kin_constraints.py
@@ -38,6 +38,7 @@ class DdtKinConstraints(KinConstraints):
         multi_observations=False,
         multi_light_profile=False,
         gamma_pl_scaling=None,
+        voronoi_bins=None,
     ):
         """
 
@@ -72,6 +73,8 @@ class DdtKinConstraints(KinConstraints):
         :param multi_light_profile: bool, if True (and if multi_observation=True) then treats the light profile input
          as a list for each individual observation condition.
         :param gamma_pl_scaling: array of mass density profile power-law slope values (optional, otherwise None)
+        :param voronoi_bins: list of voronoi bins for IFU_grid aperture (optional, otherwise None),
+            bin indices should start from 0, -1 values for pixels not binned
         """
         self._ddt_sample, self._ddt_weights = ddt_samples, ddt_weights
         self._kappa_ext_mean, self._kappa_ext_sigma = kappa_ext, kappa_ext_sigma
@@ -103,6 +106,7 @@ class DdtKinConstraints(KinConstraints):
             multi_observations=multi_observations,
             multi_light_profile=multi_light_profile,
             gamma_pl_scaling=gamma_pl_scaling,
+            voronoi_bins=voronoi_bins,
         )
 
     def hierarchy_configuration(self, num_sample_model=20):

--- a/hierarc/LensPosterior/ddt_kin_gauss_constraints.py
+++ b/hierarc/LensPosterior/ddt_kin_gauss_constraints.py
@@ -36,6 +36,7 @@ class DdtGaussKinConstraints(KinConstraints):
         num_psf_sampling=100,
         num_kin_sampling=1000,
         multi_observations=False,
+        voronoi_bins=None,
     ):
         """
 
@@ -66,6 +67,8 @@ class DdtGaussKinConstraints(KinConstraints):
         :param kappa_ext_sigma: 1-sigma distribution uncertainty from which the ddt constraints are coming from
         :param multi_observations: bool, if True, interprets kwargs_aperture and kwargs_seeing as lists of multiple
          observations
+        :param voronoi_bins: list of voronoi bins for IFU_grid aperture (optional, otherwise None),
+            bin indices should start from 0, -1 values for pixels not binned
         """
         self._ddt_mean, self._ddt_sigma = ddt_mean, ddt_sigma
         self._kappa_ext_mean, self._kappa_ext_sigma = kappa_ext, kappa_ext_sigma
@@ -95,6 +98,7 @@ class DdtGaussKinConstraints(KinConstraints):
             num_psf_sampling=num_psf_sampling,
             num_kin_sampling=num_kin_sampling,
             multi_observations=multi_observations,
+            voronoi_bins=voronoi_bins,
         )
 
     def hierarchy_configuration(self, num_sample_model=20):

--- a/hierarc/LensPosterior/kin_constraints.py
+++ b/hierarc/LensPosterior/kin_constraints.py
@@ -40,6 +40,7 @@ class KinConstraints(BaseLensConfig):
         gamma_in_scaling=None,
         log_m2l_scaling=None,
         gamma_pl_scaling=None,
+        voronoi_bins=None,
     ):
         """
 
@@ -86,6 +87,8 @@ class KinConstraints(BaseLensConfig):
         :param gamma_in_scaling: array of gamma_in parameter to be interpolated (optional, otherwise None)
         :param log_m2l_scaling: array of log_m2l parameter to be interpolated (optional, otherwise None)
         :param gamma_pl_scaling: array of mass density profile power-law slope values (optional, otherwise None)
+        :param voronoi_bins: list of voronoi bins for IFU_grid aperture (optional, otherwise None),
+            bin indices should start from 0, -1 values for pixels not binned
         """
         self._sigma_v_measured = np.array(sigma_v_measured)
         self._sigma_v_error_independent = np.array(sigma_v_error_independent)
@@ -94,6 +97,8 @@ class KinConstraints(BaseLensConfig):
 
         self._kwargs_lens_light = kwargs_lens_light
         self._anisotropy_model = anisotropy_model
+
+        self._voronoi_bins = voronoi_bins
 
         BaseLensConfig.__init__(
             self,
@@ -159,6 +164,7 @@ class KinConstraints(BaseLensConfig):
             r_eff=r_eff_draw,
             theta_E=theta_E_draw,
             gamma=gamma_draw,
+            voronoi_bins=self._voronoi_bins,
         )
         return j_kin
 

--- a/hierarc/LensPosterior/kin_constraints_composite.py
+++ b/hierarc/LensPosterior/kin_constraints_composite.py
@@ -46,6 +46,7 @@ class KinConstraintsComposite(KinConstraints):
         kappa_s_array=None,
         r_s_array=None,
         is_m2l_population_level=True,
+        voronoi_bins=None,
     ):
         """
 
@@ -92,6 +93,8 @@ class KinConstraintsComposite(KinConstraints):
         :param rho0_array: array of halo mass normalizations in M_sun / Mpc^3
         :param kappa_s_array: array of generalized NFW profile's convergence normalization at the scale radius
         :param r_s_array: array of halo scale radii in Mpc
+        :param voronoi_bins: list of voronoi bins for IFU_grid aperture (optional, otherwise None),
+            bin indices should start from 0, -1 values for pixels not binned
         """
 
         if (
@@ -153,6 +156,7 @@ class KinConstraintsComposite(KinConstraints):
             multi_observations=multi_observations,
             gamma_in_scaling=gamma_in_array,
             log_m2l_scaling=log_m2l_scaling,
+            voronoi_bins=voronoi_bins,
         )
 
         if self._check_arrays(alpha_Rs_array, r_s_angle_array):

--- a/hierarc/Likelihood/SneLikelihood/sne_pantheon_plus.py
+++ b/hierarc/Likelihood/SneLikelihood/sne_pantheon_plus.py
@@ -27,7 +27,7 @@ class PantheonPlusData(object):
             _PATH_2_DATA, "Pantheon+SH0ES", "Pantheon+SH0ES_STAT+SYS.cov"
         )
 
-        data = pd.read_csv(self._data_file, delim_whitespace=True)
+        data = pd.read_csv(self._data_file, sep='\s+')
         self.origlen = len(data)
 
         self.ww = data["zHD"] > 0.01

--- a/hierarc/Likelihood/SneLikelihood/sne_pantheon_plus.py
+++ b/hierarc/Likelihood/SneLikelihood/sne_pantheon_plus.py
@@ -27,7 +27,7 @@ class PantheonPlusData(object):
             _PATH_2_DATA, "Pantheon+SH0ES", "Pantheon+SH0ES_STAT+SYS.cov"
         )
 
-        data = pd.read_csv(self._data_file, sep='\s+')
+        data = pd.read_csv(self._data_file, sep="\s+")
         self.origlen = len(data)
 
         self.ww = data["zHD"] > 0.01

--- a/test/test_LensPosterior/test_kin_constraints.py
+++ b/test/test_LensPosterior/test_kin_constraints.py
@@ -228,6 +228,128 @@ class TestKinConstraints(object):
         )
         npt.assert_almost_equal(ln_likelihood, 0, decimal=1)
 
+    def test_likelihoodconfiguration_voronoi_bins(self):
+        anisotropy_model = "const"
+        x = y = np.linspace(-5, 5, 20)
+        x_grid, y_grid = np.meshgrid(x, y)
+        kwargs_aperture = {
+            "aperture_type": "IFU_grid",
+            "x_grid": x_grid,
+            "y_grid": y_grid,
+        }
+        voronoi_bins = np.ones_like(x_grid) * -1
+        voronoi_bins[3:-2, 3:-2] = np.kron(np.arange(25).reshape(5,5), np.ones((3,3))).astype(int)
+        kwargs_seeing = {"psf_type": "GAUSSIAN", "fwhm": 1.4}
+
+        # numerical settings (not needed if power-law profiles with Hernquist light distribution is computed)
+        kwargs_numerics_galkin = {
+            "interpol_grid_num": 1000,  # numerical interpolation, should converge -> infinity
+            "log_integration": True,
+            # log or linear interpolation of surface brightness and mass models
+            "max_integrate": 100,
+            "min_integrate": 0.001,
+        }  # lower/upper bound of numerical integrals
+
+        # redshift
+        z_lens = 0.5
+        z_source = 1.5
+
+        # lens model
+        from astropy.cosmology import FlatLambdaCDM
+
+        cosmo = FlatLambdaCDM(H0=70, Om0=0.3)
+        theta_E = 1.0
+        r_eff = 1
+        gamma = 2.1
+
+        # kwargs_model
+        lens_light_model_list = ["HERNQUIST"]
+        lens_model_list = ["SPP"]
+        kwargs_model = {
+            "lens_model_list": lens_model_list,
+            "lens_light_model_list": lens_light_model_list,
+        }
+
+        # settings for kinematics calculation with KinematicsAPI of lenstronomy
+        kwargs_kin_api_settings = {
+            "multi_observations": False,
+            "kwargs_numerics_galkin": kwargs_numerics_galkin,
+            "MGE_light": False,
+            "kwargs_mge_light": None,
+            "sampling_number": 1000,
+            "num_kin_sampling": 1000,
+            "num_psf_sampling": 100,
+        }
+
+        kin_api = KinematicsAPI(
+            z_lens,
+            z_source,
+            kwargs_model,
+            kwargs_aperture,
+            kwargs_seeing,
+            anisotropy_model,
+            cosmo=cosmo,
+            **kwargs_kin_api_settings
+        )
+
+        # compute kinematics with fiducial cosmology
+        kwargs_lens = [
+            {"theta_E": theta_E, "gamma": gamma, "center_x": 0, "center_y": 0}
+        ]
+        beta_inf = 0.9
+        kwargs_lens_light = [{"Rs": r_eff * 0.551, "amp": 1.0}]
+        kwargs_anisotropy = {"beta": 0.0}
+        sigma_v_map_voronoi = kin_api.velocity_dispersion_map(
+            kwargs_lens,
+            kwargs_lens_light,
+            kwargs_anisotropy,
+            r_eff=r_eff,
+            theta_E=theta_E,
+            gamma=gamma,
+            kappa_ext=0,
+            voronoi_bins=voronoi_bins,
+        )
+
+        def paint_map(bin_map, values):
+            """
+            Paint per-bin values back to a 2D map.
+            """
+            out = np.full_like(bin_map, np.nan, dtype=float)
+            bins = np.unique(bin_map[bin_map > 0])
+            for i, b in enumerate(bins):
+                out[bin_map == b] = values[i]
+            return out
+
+        import matplotlib.pyplot as plt
+        plt.imshow(paint_map(voronoi_bins, sigma_v_map_voronoi))
+        plt.colorbar()
+        plt.show()
+
+        # compute likelihood
+        kin_constraints = KinConstraints(
+            z_lens=z_lens,
+            z_source=z_source,
+            theta_E=theta_E,
+            theta_E_error=0.01,
+            gamma=gamma,
+            gamma_error=0.02,
+            r_eff=r_eff,
+            r_eff_error=0.05,
+            sigma_v_measured=sigma_v_map_voronoi,
+            sigma_v_error_independent=np.ones(sigma_v_map_voronoi.size) * 10,
+            sigma_v_error_cov_matrix=np.eye(sigma_v_map_voronoi.size) * 100,
+            sigma_v_error_covariant=0,
+            kwargs_aperture=kwargs_aperture,
+            kwargs_seeing=kwargs_seeing,
+            anisotropy_model=anisotropy_model,
+            gamma_pl_scaling=np.linspace(1.8, 2.2, 5),
+            voronoi_bins=voronoi_bins,
+            **kwargs_kin_api_settings
+        )
+
+        kwargs_likelihood = kin_constraints.hierarchy_configuration(num_sample_model=5)
+        assert len(kwargs_likelihood["j_kin_scaling_grid_list"]) == len(np.unique(voronoi_bins[voronoi_bins > -1]))
+
 
 class TestRaise(unittest.TestCase):
     def test_raise(self):

--- a/test/test_LensPosterior/test_kin_constraints.py
+++ b/test/test_LensPosterior/test_kin_constraints.py
@@ -310,21 +310,6 @@ class TestKinConstraints(object):
             voronoi_bins=voronoi_bins,
         )
 
-        def paint_map(bin_map, values):
-            """
-            Paint per-bin values back to a 2D map.
-            """
-            out = np.full_like(bin_map, np.nan, dtype=float)
-            bins = np.unique(bin_map[bin_map > 0])
-            for i, b in enumerate(bins):
-                out[bin_map == b] = values[i]
-            return out
-
-        import matplotlib.pyplot as plt
-        plt.imshow(paint_map(voronoi_bins, sigma_v_map_voronoi))
-        plt.colorbar()
-        plt.show()
-
         # compute likelihood
         kin_constraints = KinConstraints(
             z_lens=z_lens,

--- a/test/test_LensPosterior/test_kin_constraints.py
+++ b/test/test_LensPosterior/test_kin_constraints.py
@@ -238,7 +238,9 @@ class TestKinConstraints(object):
             "y_grid": y_grid,
         }
         voronoi_bins = np.ones_like(x_grid) * -1
-        voronoi_bins[3:-2, 3:-2] = np.kron(np.arange(25).reshape(5,5), np.ones((3,3))).astype(int)
+        voronoi_bins[3:-2, 3:-2] = np.kron(
+            np.arange(25).reshape(5, 5), np.ones((3, 3))
+        ).astype(int)
         kwargs_seeing = {"psf_type": "GAUSSIAN", "fwhm": 1.4}
 
         # numerical settings (not needed if power-law profiles with Hernquist light distribution is computed)
@@ -333,7 +335,9 @@ class TestKinConstraints(object):
         )
 
         kwargs_likelihood = kin_constraints.hierarchy_configuration(num_sample_model=5)
-        assert len(kwargs_likelihood["j_kin_scaling_grid_list"]) == len(np.unique(voronoi_bins[voronoi_bins > -1]))
+        assert len(kwargs_likelihood["j_kin_scaling_grid_list"]) == len(
+            np.unique(voronoi_bins[voronoi_bins > -1])
+        )
 
 
 class TestRaise(unittest.TestCase):


### PR DESCRIPTION
This pull request adds the ability to use Voronoi (or other) binning when using the `"IFU_grid"` aperture type for kinematic preprocessing (estimating the mean, covariance, and interpolation grid of the dimensionless kinematic map). It adds a new argument `voronoi_bins` when instancing the class `KinConstraints` (and derived classes) to use that binning for preprocessing. The arguments `sigma_v_measured`, `sigma_v_error_independent`, and `sigma_v_error_cov_matrix` should also be obtained  using the same binning.

```ptyhon
kin_constraints = KinConstraints(
    ...
    sigma_v_measured=sigma_v_map_voronoi_binned,
    voronoi_bins=voronoi_bins,
    ...
)

```