### PR TITLE
Support AstroPy 7

### DIFF
--- a/hierarc/Sampling/ParamManager/cosmo_model.py
+++ b/hierarc/Sampling/ParamManager/cosmo_model.py
@@ -3,12 +3,14 @@ from astropy.cosmology import FLRW, FlatFLRWMixin
 from scipy.special import exp1
 from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
+
 try:
     # AstroPy 7
     from astropy.cosmology._src.utils import aszarr
 except:
     # AstroPy 6
     from astropy.cosmology._utils import aszarr
+
 
 @dataclass_decorator
 class wPhiCDM(FlatFLRWMixin, FLRW):

--- a/hierarc/Sampling/ParamManager/cosmo_model.py
+++ b/hierarc/Sampling/ParamManager/cosmo_model.py
@@ -3,8 +3,12 @@ from astropy.cosmology import FLRW, FlatFLRWMixin
 from scipy.special import exp1
 from astropy.cosmology.core import dataclass_decorator
 from astropy.cosmology.parameter import Parameter
-from astropy.cosmology._utils import aszarr
-
+try:
+    # AstroPy 7
+    from astropy.cosmology._src.utils import aszarr
+except:
+    # AstroPy 6
+    from astropy.cosmology._utils import aszarr
 
 @dataclass_decorator
 class wPhiCDM(FlatFLRWMixin, FLRW):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy<2
-astropy<7
+numpy
+astropy
 
 scipy<1.14
 emcee


### PR DESCRIPTION
This adds support for AstroPy 7. It also removes the pin for NumPy 1, as all tests pass with NumPy 2.

Goal is to package hierArc in Guix, which is phasing out all AstroPy 6 and NumPy 1 packages.
