### PR TITLE
fix angular_diameter_distance warning when using z as kwarg

### DIFF
--- a/hierarc/Likelihood/LensLikelihood/double_source_plane.py
+++ b/hierarc/Likelihood/LensLikelihood/double_source_plane.py
@@ -59,9 +59,9 @@ def beta_double_source_plane(z_lens, z_source_1, z_source_2, cosmo):
     :param cosmo: ~astropy.cosmology instance
     :return: beta
     """
-    ds1 = cosmo.angular_diameter_distance(z=z_source_1).value
+    ds1 = cosmo.angular_diameter_distance(z_source_1).value
     dds1 = cosmo.angular_diameter_distance_z1z2(z1=z_lens, z2=z_source_1).value
-    ds2 = cosmo.angular_diameter_distance(z=z_source_2).value
+    ds2 = cosmo.angular_diameter_distance(z_source_2).value
     dds2 = cosmo.angular_diameter_distance_z1z2(z1=z_lens, z2=z_source_2).value
     beta = dds1 / ds1 * ds2 / dds2
     return beta

--- a/hierarc/Likelihood/hierarchy_likelihood.py
+++ b/hierarc/Likelihood/hierarchy_likelihood.py
@@ -412,8 +412,8 @@ class LensLikelihood(TransformedCosmography, LensLikelihoodBase, KinScaling):
         """
         if self.likelihood_type in ["DSPL"]:
             return 0, 0  # just returns some random numbers as not being used
-        dd = cosmo.angular_diameter_distance(z=self.z_lens).value
-        ds = cosmo.angular_diameter_distance(z=self.z_source).value
+        dd = cosmo.angular_diameter_distance(self.z_lens).value
+        ds = cosmo.angular_diameter_distance(self.z_source).value
         dds = cosmo.angular_diameter_distance_z1z2(
             z1=self.z_lens, z2=self.z_source
         ).value

--- a/test/test_Likelihood/test_cosmo_likelihood.py
+++ b/test/test_Likelihood/test_cosmo_likelihood.py
@@ -196,11 +196,11 @@ class TestCosmoLikelihood(object):
         cosmo_interp_input = cosmoL.cosmo_instance(kwargs_cosmo_interp)
 
         z = 1
-        dd_astropy = cosmo_astropy.angular_diameter_distance(z=z).value
-        dd_interp = cosmo_interp.angular_diameter_distance(z=z).value
-        dd_interp_input = cosmo_interp_input.angular_diameter_distance(z=z).value
-        dd_fixed = cosmo_fixed.angular_diameter_distance(z=z).value
-        dd_fixed_interp = cosmo_fixed_interp.angular_diameter_distance(z=z).value
+        dd_astropy = cosmo_astropy.angular_diameter_distance(z).value
+        dd_interp = cosmo_interp.angular_diameter_distance(z).value
+        dd_interp_input = cosmo_interp_input.angular_diameter_distance(z).value
+        dd_fixed = cosmo_fixed.angular_diameter_distance(z).value
+        dd_fixed_interp = cosmo_fixed_interp.angular_diameter_distance(z).value
 
         npt.assert_almost_equal(dd_astropy, dd_interp, decimal=1)
         npt.assert_almost_equal(dd_astropy, dd_interp_input, decimal=1)

--- a/test/test_Likelihood/test_hierarchy_likelihood.py
+++ b/test/test_Likelihood/test_hierarchy_likelihood.py
@@ -11,8 +11,8 @@ class TestLensLikelihood(object):
         z_lens = 0.5
         z_source = 1.5
         self.cosmo = FlatLambdaCDM(H0=70, Om0=0.3, Ob0=0.05)
-        dd = self.cosmo.angular_diameter_distance(z=z_lens).value
-        ds = self.cosmo.angular_diameter_distance(z=z_source).value
+        dd = self.cosmo.angular_diameter_distance(z_lens).value
+        ds = self.cosmo.angular_diameter_distance(z_source).value
         dds = self.cosmo.angular_diameter_distance_z1z2(z1=z_lens, z2=z_source).value
         ddt = (1.0 + z_lens) * dd * ds / dds
 
@@ -337,8 +337,8 @@ class TestLensLikelihood(object):
             "alpha_log_m2l": 1000,
         }
 
-        dd = self.cosmo.angular_diameter_distance(z=z_lens).value
-        ds = self.cosmo.angular_diameter_distance(z=z_source).value
+        dd = self.cosmo.angular_diameter_distance(z_lens).value
+        ds = self.cosmo.angular_diameter_distance(z_source).value
         dds = self.cosmo.angular_diameter_distance_z1z2(z1=z_lens, z2=z_source).value
         ddt = (1.0 + z_lens) * dd * ds / dds
 


### PR DESCRIPTION
This pull request avoids producing one warning for every particle sampled in the MCMC due to an astropy `FutureWarning`